### PR TITLE
Adding latest API changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 ### Added
 
 - Added `availablePaymentMethods` as an `include` Parameter to all transaction operations.
+- Added `importMeta` to Subscription webhooks.
 
 ### Changed
 
@@ -22,6 +23,10 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 ### Fixed
 
 - Fixed `effective_from` enum in Resume subscription operations.
+
+### Deprecated
+
+- Deprecated `storedPaymentMethodId` from transaction payments in favour of `paymentMethodId` field.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-node-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## 0.4.0 - 2024-02-14
+
+### Added
+
+- Added `availablePaymentMethods` as an `include` Parameter to all transaction operations.
+
+### Changed
+
+- Filter customers by email address in `customers.list()` operation, see [related changelog](https://developer.paddle.com/changelog/2024/filter-customers-email?utm_source=dx&utm_medium=paddle-node-sdk).
+- New payment method ID field for transaction payments, see [related changelog](https://developer.paddle.com/changelog/2024/payment-method-paddle-id?utm_source=dx&utm_medium=paddle-node-sdk).
+
+### Fixed
+
+- Fixed `effective_from` enum in Resume subscription operations.
+
+---
+
 ## 0.3.0 - 2024-01-11
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-node-sdk",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A Node.js SDK that you can use to integrate Paddle Billing with applications written in server-side JavaScript.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/__tests__/mocks/notifications/subscription-activated.mock.ts
+++ b/src/__tests__/mocks/notifications/subscription-activated.mock.ts
@@ -94,6 +94,7 @@ export const SubscriptionActivatedMockExpectation = {
       startsAt: '2023-08-11T08:07:35.449123Z',
     },
     customData: null,
+    importMeta: null,
     customerId: 'ctm_01h7hswb86rtps5ggbq7ybydcw',
     discount: null,
     firstBilledAt: '2023-08-11T08:07:35.449123Z',

--- a/src/__tests__/mocks/notifications/subscription-canceled.mock.ts
+++ b/src/__tests__/mocks/notifications/subscription-canceled.mock.ts
@@ -109,6 +109,7 @@ export const SubscriptionCanceledMockExpectation = {
     currencyCode: 'USD',
     currentBillingPeriod: null,
     customData: null,
+    importMeta: null,
     customerId: 'ctm_01h7hswb86rtps5ggbq7ybydcw',
     discount: null,
     firstBilledAt: '2023-08-11T08:07:35.449123Z',

--- a/src/__tests__/mocks/notifications/subscription-created.mock.ts
+++ b/src/__tests__/mocks/notifications/subscription-created.mock.ts
@@ -94,6 +94,7 @@ export const SubscriptionCreatedMockExpectation = {
       startsAt: '2023-08-11T08:07:35.449123Z',
     },
     customData: null,
+    importMeta: null,
     customerId: 'ctm_01h7hswb86rtps5ggbq7ybydcw',
     discount: null,
     firstBilledAt: '2023-08-11T08:07:35.449123Z',

--- a/src/__tests__/mocks/notifications/subscription-imported.mock.ts
+++ b/src/__tests__/mocks/notifications/subscription-imported.mock.ts
@@ -109,6 +109,7 @@ export const SubscriptionImportedMockExpectation = {
       startsAt: '2023-04-13T09:07:04.730931Z',
     },
     customData: null,
+    importMeta: null,
     customerId: 'ctm_01gxwxe6vzgz6hcsbwjs6zrszr',
     discount: null,
     firstBilledAt: '2023-04-13T09:07:04.730931Z',

--- a/src/__tests__/mocks/notifications/subscription-past-due.mock.ts
+++ b/src/__tests__/mocks/notifications/subscription-past-due.mock.ts
@@ -94,6 +94,7 @@ export const SubscriptionPastDueMockExpectation = {
       startsAt: '2023-10-11T08:07:35.449123Z',
     },
     customData: null,
+    importMeta: null,
     customerId: 'ctm_01h7hswb86rtps5ggbq7ybydcw',
     discount: null,
     firstBilledAt: '2023-08-11T08:07:35.449123Z',

--- a/src/__tests__/mocks/notifications/subscription-paused.mock.ts
+++ b/src/__tests__/mocks/notifications/subscription-paused.mock.ts
@@ -91,6 +91,7 @@ export const SubscriptionPausedMockExpectation = {
     currencyCode: 'USD',
     currentBillingPeriod: null,
     customData: null,
+    importMeta: null,
     customerId: 'ctm_01h7hswb86rtps5ggbq7ybydcw',
     discount: null,
     firstBilledAt: '2023-08-11T08:07:35.449123Z',

--- a/src/__tests__/mocks/notifications/subscription-resumed.mock.ts
+++ b/src/__tests__/mocks/notifications/subscription-resumed.mock.ts
@@ -94,6 +94,7 @@ export const SubscriptionResumedMockExpectation = {
       startsAt: '2023-11-11T08:33:04.443903Z',
     },
     customData: null,
+    importMeta: null,
     customerId: 'ctm_01h7hswb86rtps5ggbq7ybydcw',
     discount: null,
     firstBilledAt: '2023-08-11T08:07:35.449123Z',

--- a/src/__tests__/mocks/notifications/subscription-trialing.mock.ts
+++ b/src/__tests__/mocks/notifications/subscription-trialing.mock.ts
@@ -75,6 +75,7 @@ export const SubscriptionTrialingMockExpectation = {
       startsAt: '2023-08-18T13:15:46.864158Z',
     },
     customData: null,
+    importMeta: null,
     customerId: 'ctm_01h84cjfwmdph1k8kgsyjt3k7g',
     discount: null,
     firstBilledAt: null,

--- a/src/__tests__/mocks/notifications/subscription-updated.mock.ts
+++ b/src/__tests__/mocks/notifications/subscription-updated.mock.ts
@@ -94,6 +94,7 @@ export const SubscriptionUpdatedMockExpectation = {
       startsAt: '2023-09-11T08:07:35.449123Z',
     },
     customData: null,
+    importMeta: null,
     customerId: 'ctm_01h7hswb86rtps5ggbq7ybydcw',
     discount: null,
     firstBilledAt: '2023-08-11T08:07:35.449123Z',

--- a/src/__tests__/resources/transactions.test.ts
+++ b/src/__tests__/resources/transactions.test.ts
@@ -113,7 +113,7 @@ describe('TransactionsResource', () => {
     const transactionsResource = new TransactionsResource(paddleInstance);
     const updatedTransaction = await transactionsResource.update(transactionId, transactionToBeUpdated);
 
-    expect(paddleInstance.patch).toBeCalledWith(`/transactions/${transactionId}`, transactionToBeUpdated);
+    expect(paddleInstance.patch).toBeCalledWith(`/transactions/${transactionId}?`, transactionToBeUpdated);
     expect(updatedTransaction).toBeDefined();
     expect(convertToSnakeCase(UpdateTransactionMock)).toEqual(UpdateTransactionExpectation);
   });

--- a/src/entities/shared/transaction-payment-attempt.ts
+++ b/src/entities/shared/transaction-payment-attempt.ts
@@ -10,6 +10,10 @@ import { type PaymentAttemptStatus, type ErrorCode } from '../../enums';
 
 export class TransactionPaymentAttempt {
   public readonly paymentAttemptId: string;
+  public readonly paymentMethodId: string;
+  /**
+   * @deprecated use paymentMethodId instead
+   */
   public readonly storedPaymentMethodId: string;
   public readonly amount: string;
   public readonly status: PaymentAttemptStatus;
@@ -20,6 +24,7 @@ export class TransactionPaymentAttempt {
 
   constructor(transactionPaymentAttempt: ITransactionPaymentAttemptResponse) {
     this.paymentAttemptId = transactionPaymentAttempt.payment_attempt_id;
+    this.paymentMethodId = transactionPaymentAttempt.payment_method_id;
     this.storedPaymentMethodId = transactionPaymentAttempt.stored_payment_method_id;
     this.amount = transactionPaymentAttempt.amount;
     this.status = transactionPaymentAttempt.status;

--- a/src/entities/subscription/subscription-notification.ts
+++ b/src/entities/subscription/subscription-notification.ts
@@ -7,6 +7,7 @@
 import {
   BillingDetails,
   type CustomData,
+  ImportMeta,
   SubscriptionDiscount,
   SubscriptionItem,
   SubscriptionScheduledChange,
@@ -39,6 +40,7 @@ export class SubscriptionNotification {
   public readonly scheduledChange: SubscriptionScheduledChange | null;
   public readonly items: SubscriptionItem[];
   public readonly customData: CustomData | null;
+  public readonly importMeta: ImportMeta | null;
 
   constructor(subscription: ISubscriptionNotificationResponse) {
     this.id = subscription.id;
@@ -67,5 +69,6 @@ export class SubscriptionNotification {
       : null;
     this.items = subscription.items.map((item) => new SubscriptionItem(item));
     this.customData = subscription.custom_data ? subscription.custom_data : null;
+    this.importMeta = subscription.import_meta ? new ImportMeta(subscription.import_meta) : null;
   }
 }

--- a/src/entities/transaction/transaction-includes.ts
+++ b/src/entities/transaction/transaction-includes.ts
@@ -21,6 +21,7 @@ import {
   TransactionsTimePeriod,
 } from '../index';
 import { type CollectionMode, type CurrencyCode, type TransactionStatus, type TransactionOrigin } from '../../enums';
+import { type AvailablePaymentMethod } from '../../enums/shared/available-payment-methods';
 
 export class TransactionIncludes {
   public readonly id: string;
@@ -51,6 +52,7 @@ export class TransactionIncludes {
   public readonly business: Business | null;
   public readonly customer: Customer | null;
   public readonly discount: Discount | null;
+  public readonly availablePaymentMethods: AvailablePaymentMethod[] | null;
 
   constructor(transaction: ITransactionResponse) {
     this.id = transaction.id;
@@ -85,5 +87,6 @@ export class TransactionIncludes {
     this.business = transaction.business ? new Business(transaction.business) : null;
     this.customer = transaction.customer ? new Customer(transaction.customer) : null;
     this.discount = transaction.discount ? new Discount(transaction.discount) : null;
+    this.availablePaymentMethods = transaction.available_payment_methods ? transaction.available_payment_methods : null;
   }
 }

--- a/src/resources/customers/operations/list-customer-query-parameters.ts
+++ b/src/resources/customers/operations/list-customer-query-parameters.ts
@@ -12,4 +12,5 @@ export interface ListCustomerQueryParameters {
   perPage?: number;
   search?: string;
   status?: Status[];
+  email?: string[];
 }

--- a/src/resources/subscriptions/operations/resume-subscription-request-object.ts
+++ b/src/resources/subscriptions/operations/resume-subscription-request-object.ts
@@ -4,8 +4,6 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-import { type SubscriptionEffectiveFrom } from '../../../enums';
-
 export interface ResumeSubscription {
-  effectiveFrom: SubscriptionEffectiveFrom | string;
+  effectiveFrom: 'immediately' | string;
 }

--- a/src/resources/transactions/index.ts
+++ b/src/resources/transactions/index.ts
@@ -4,13 +4,7 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-import {
-  Transaction,
-  TransactionCollection,
-  TransactionIncludes,
-  TransactionInvoicePDF,
-  TransactionPreview,
-} from '../../entities';
+import { TransactionCollection, TransactionIncludes, TransactionInvoicePDF, TransactionPreview } from '../../entities';
 import { type ErrorResponse, type Response } from '../../internal';
 import { BaseResource, PathParameters, QueryParameters } from '../../internal/base';
 import {
@@ -20,6 +14,7 @@ import {
   type ListTransactionQueryParameters,
   type UpdateTransactionRequestBody,
   type TransactionPreviewRequestBody,
+  type UpdateTransactionQueryParameters,
 } from './operations';
 import { type ITransactionResponse, type ITransactionInvoicePDF, type ITransactionPreviewResponse } from '../../types';
 
@@ -55,7 +50,12 @@ export class TransactionsResource extends BaseResource {
     return new TransactionIncludes(data);
   }
 
-  public async update(transactionId: string, updateTransaction: UpdateTransactionRequestBody): Promise<Transaction> {
+  public async update(
+    transactionId: string,
+    updateTransaction: UpdateTransactionRequestBody,
+    queryParams?: UpdateTransactionQueryParameters,
+  ): Promise<TransactionIncludes> {
+    const queryParameters = new QueryParameters(queryParams);
     const urlWithPathParams = new PathParameters(TransactionPaths.update, {
       transaction_id: transactionId,
     }).deriveUrl();
@@ -63,11 +63,11 @@ export class TransactionsResource extends BaseResource {
     const response = await this.client.patch<
       UpdateTransactionRequestBody,
       Response<ITransactionResponse> | ErrorResponse
-    >(urlWithPathParams, updateTransaction);
+    >(urlWithPathParams + queryParameters.toQueryString(), updateTransaction);
 
     const data = this.handleResponse<ITransactionResponse>(response);
 
-    return new Transaction(data);
+    return new TransactionIncludes(data);
   }
 
   public async get(transactionId: string, queryParams?: GetTransactionQueryParameters): Promise<TransactionIncludes> {

--- a/src/resources/transactions/operations/index.ts
+++ b/src/resources/transactions/operations/index.ts
@@ -6,6 +6,7 @@
 
 export * from './list-transaction-query-parameters';
 export * from './create-transaction-query-parameters';
+export * from './update-transaction-query-parameters';
 export * from './create-transaction-request-body';
 export * from './get-transaction-query-parameters';
 export * from './update-transaction-request-body';

--- a/src/resources/transactions/operations/update-transaction-query-parameters.ts
+++ b/src/resources/transactions/operations/update-transaction-query-parameters.ts
@@ -4,7 +4,7 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-export interface CreateTransactionQueryParameters {
+export interface UpdateTransactionQueryParameters {
   include?: Array<
     'address' | 'adjustment' | 'adjustments_totals' | 'available_payment_methods' | 'business' | 'customer' | 'discount'
   >;

--- a/src/types/shared/transaction-payment-attempt-response.ts
+++ b/src/types/shared/transaction-payment-attempt-response.ts
@@ -9,7 +9,11 @@ import { type PaymentAttemptStatus, type ErrorCode } from '../../enums';
 
 export interface ITransactionPaymentAttemptResponse {
   payment_attempt_id: string;
+  /**
+   * @deprecated use payment_method_id instead
+   */
   stored_payment_method_id: string;
+  payment_method_id: string;
   amount: string;
   status: PaymentAttemptStatus;
   error_code?: ErrorCode | null;

--- a/src/types/subscription/subscription-notification-response.ts
+++ b/src/types/subscription/subscription-notification-response.ts
@@ -7,6 +7,7 @@
 import {
   type IBillingDetailsResponse,
   type ICustomData,
+  type IImportMetaResponse,
   type INextTransactionResponse,
   type ISubscriptionDiscountResponse,
   type ISubscriptionItemResponse,
@@ -40,6 +41,7 @@ export interface ISubscriptionNotificationResponse {
   scheduled_change?: ISubscriptionScheduledChangeResponse | null;
   items: ISubscriptionItemResponse[];
   custom_data?: ICustomData | null;
+  import_meta?: IImportMetaResponse | null;
   next_transaction?: INextTransactionResponse | null;
   recurring_transaction_details?: ITransactionDetailsPreviewResponse | null;
 }

--- a/src/types/transaction/transaction-response.ts
+++ b/src/types/transaction/transaction-response.ts
@@ -20,6 +20,7 @@ import {
   type IDiscountResponse,
 } from '../index';
 import { type TransactionStatus, type CurrencyCode, type TransactionOrigin, type CollectionMode } from '../../enums';
+import { type AvailablePaymentMethod } from '../../enums/shared/available-payment-methods';
 
 export interface ITransactionResponse {
   id: string;
@@ -50,4 +51,5 @@ export interface ITransactionResponse {
   business?: IBusinessResponse | null;
   customer?: ICustomerResponse | null;
   discount?: IDiscountResponse | null;
+  available_payment_methods?: AvailablePaymentMethod[] | null;
 }


### PR DESCRIPTION
## 0.4.0 - 2024-02-14

### Added

- Added `availablePaymentMethods` as an `include` Parameter to all transaction operations.
- Added `importMeta` to Subscription webhooks.

### Changed

- Filter customers by email address in `customers.list()` operation, see [related changelog](https://developer.paddle.com/changelog/2024/filter-customers-email?utm_source=dx&utm_medium=paddle-node-sdk).
- New payment method ID field for transaction payments, see [related changelog](https://developer.paddle.com/changelog/2024/payment-method-paddle-id?utm_source=dx&utm_medium=paddle-node-sdk).

### Fixed

- Fixed `effective_from` enum in Resume subscription operations.

### Deprecated

- Deprecated `storedPaymentMethodId` from transaction payments in favour of `paymentMethodId` field.

---