### PR TITLE
Support Cloudflare with dynamic import for 'node:crypto'

### DIFF
--- a/src/internal/api/client.ts
+++ b/src/internal/api/client.ts
@@ -4,10 +4,15 @@ import fetch from 'node-fetch';
 import { SDK_VERSION } from '../../version';
 import { type PaddleOptions } from '../types/config';
 import { Environment } from './environment';
-import { randomUUID } from 'crypto';
 import { Logger } from '../base/logger';
 import { convertToSnakeCase } from './case-helpers';
 import { type ErrorResponse } from '../types/response';
+import type { randomUUID as randomUUIDFn } from 'node:crypto';
+let randomUUID: typeof randomUUIDFn;
+(async () => {
+  const crypto = await import('node:crypto');
+  randomUUID = crypto.randomUUID;
+})();
 
 export class Client {
   private readonly baseUrl: string;

--- a/src/notifications/helpers/webhooks-validator.ts
+++ b/src/notifications/helpers/webhooks-validator.ts
@@ -1,4 +1,9 @@
-import { createHmac } from 'crypto';
+import type { createHmac as createHmacFn } from 'node:crypto';
+let createHmac: typeof createHmacFn;
+(async () => {
+  const crypto = await import('node:crypto');
+  createHmac = crypto.createHmac;
+})();
 
 interface ParsedHeaders {
   ts: number;


### PR DESCRIPTION
Closes #9 

[paddle-node-sdk](https://github.com/PaddleHQ/paddle-node-sdk) does not run on Cloudflare because it imports `crypto` without a `node:` prefix. Node.js compatibility in Cloudflare requires the `node:` prefix per https://developers.cloudflare.com/workers/runtime-apis/nodejs/

`paddle-node-sdk` is cjs and `node:crypto` on Cloudflare seems to be esm. Cjs must use a dynamic import to import esm.

This PR dynamically imports 'node:crypto'.

In my local environment, 4 tests fail when I run the latest `main` in `paddle-node-sdk`. These 4 failures persist with this PR.

<img width="478" alt="Screenshot 2024-03-10 at 8 15 47 PM" src="https://github.com/PaddleHQ/paddle-node-sdk/assets/425584/07dae914-46bd-4b8b-81f4-b0a7c51cfed8">

https://github.com/mw10013/paddle-cloudflare-worker contains a Cloudflare worker that uses this PR to show the first page of products on Cloudflare. It is deployed here: https://paddle-cloudflare-worker.mw10013.workers.dev/


