### PR TITLE
Added customerId to address and business entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 
 ### Changed
 
-- Added `customerId` property to `Address` and `Business` entities.
+- Added `customerId` property to `Address` and `Business` entities, see [related changelog](https://developer.paddle.com/changelog/2024/address-business-webhooks-customer-id?utm_source=dx&utm_medium=paddle-node-sdk).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-node-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
 
+## 1.0.2 - 2024-03-12
+
+### Added
+
+- Exported `ApiError` class for usage in `try/catch` block.
+
+### Changed
+
+- Added `customerId` property to `Address` and `Business` entities.
+
+---
+
 ## 1.0.1 - 2024-02-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -206,6 +206,26 @@ const product = await archiveProduct('id')
 console.log('Product', product)
 ```
 
+### Error Handling
+
+If a request fails, Paddle returns an `error` object that contains the same information as [errors returned by the API](https://developer.paddle.com/api-reference/about/errors?utm_source=dx&utm_medium=paddle-node-sdk). You can use the `code` attribute to search an error in [the error reference](https://developer.paddle.com/errors/overview?utm_source=dx&utm_medium=paddle-node-sdk) and to handle the error in your app. Validation errors also return an array of `errors` that tell you which fields failed validation.
+
+This example shows how to handle an error with the code `conflict`:
+
+```typescript
+import { ApiError } from '@paddle/paddle-node-sdk'
+
+try {
+  // Call functions from the SDK
+} catch (e: any) {
+  // e.code will always follow the error code defined in our documentation
+  const paddleApiError = e as ApiError;
+  if (paddleApiError.code === 'conflict') {
+    // Handle Conflict error
+  }
+}
+```
+
 ## Resources
 
 ### Webhook signature verification 

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,7 +9,14 @@ const config = {
   testMatch: ['**/__tests__/**/*.test.ts'],
   testPathIgnorePatterns: ['/node_modules/', '/dist/'],
   cacheDirectory: process.env.JEST_CACHE_FOLDER || '/tmp/node-sdk/.jest-cache',
-  coveragePathIgnorePatterns: ['/src/types/', '__tests__', '/src/enums/', 'operations'],
+  coveragePathIgnorePatterns: [
+    '/src/types/',
+    '__tests__',
+    '/src/enums/',
+    'operations',
+    'index.ts',
+    'src/notifications/types',
+  ],
 };
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-node-sdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A Node.js SDK that you can use to integrate Paddle Billing with applications written in server-side JavaScript.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/__tests__/mocks/notifications/address-created.mock.ts
+++ b/src/__tests__/mocks/notifications/address-created.mock.ts
@@ -4,9 +4,10 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-import { type IEventsResponse, type IAddressResponse } from '../../../types';
+import { type IEventsResponse } from '../../../types';
+import { IAddressNotificationResponse } from '../../../notifications';
 
-export const AddressCreatedMock: IEventsResponse<IAddressResponse> = {
+export const AddressCreatedMock: IEventsResponse<IAddressNotificationResponse> = {
   event_id: 'evt_01h848pezaj15tkt3dsa36xe59',
   event_type: 'address.created',
   occurred_at: '2023-08-18T12:07:37.194676Z',
@@ -33,6 +34,7 @@ export const AddressCreatedMockExpectation = {
     countryCode: 'US',
     createdAt: '2023-08-18T12:07:36.9Z',
     customData: null,
+    customerId: null,
     description: 'Head Office',
     firstLine: '4050 Jefferson Plaza, 41st Floor',
     id: 'add_01h848pep46enq8y372x7maj0p',

--- a/src/__tests__/mocks/notifications/address-imported.mock.ts
+++ b/src/__tests__/mocks/notifications/address-imported.mock.ts
@@ -4,9 +4,10 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-import { type IEventsResponse, type IAddressResponse } from '../../../types';
+import { type IEventsResponse } from '../../../types';
+import { IAddressNotificationResponse } from '../../../notifications';
 
-export const AddressImportedMock: IEventsResponse<IAddressResponse> = {
+export const AddressImportedMock: IEventsResponse<IAddressNotificationResponse> = {
   event_id: 'evt_01hhy7cva3jgaez82k6n4n3x4b',
   event_type: 'address.imported',
   occurred_at: '2023-08-18T12:07:37.194676Z',
@@ -34,6 +35,7 @@ export const AddressImportedMockExpectation = {
     countryCode: 'US',
     createdAt: '2023-08-18T12:07:36.9Z',
     customData: null,
+    customerId: null,
     description: 'Head Office',
     firstLine: '4050 Jefferson Plaza, 41st Floor',
     id: 'add_01h848pep46enq8y372x7maj0p',

--- a/src/__tests__/mocks/notifications/address-updated.mock.ts
+++ b/src/__tests__/mocks/notifications/address-updated.mock.ts
@@ -4,9 +4,10 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-import { type IEventsResponse, type IAddressResponse } from '../../../types';
+import { type IEventsResponse } from '../../../types';
+import { IAddressNotificationResponse } from '../../../notifications';
 
-export const AddressUpdatedMock: IEventsResponse<IAddressResponse> = {
+export const AddressUpdatedMock: IEventsResponse<IAddressNotificationResponse> = {
   event_id: 'evt_01h849k5rs5jxgctb45s6pmkat',
   event_type: 'address.updated',
   occurred_at: '2023-08-18T12:23:18.041154Z',
@@ -33,6 +34,7 @@ export const AddressUpdatedMockExpectation = {
     countryCode: 'US',
     createdAt: '2023-08-18T12:22:44.543Z',
     customData: null,
+    customerId: null,
     description: 'California Office',
     firstLine: '5400 E Washington Drive, Floor 2',
     id: 'add_01h849j51zpxv1e3zy2vgrrk6a',

--- a/src/__tests__/mocks/notifications/business-created.mock.ts
+++ b/src/__tests__/mocks/notifications/business-created.mock.ts
@@ -4,9 +4,10 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-import { type IEventsResponse, type IBusinessResponse } from '../../../types';
+import { type IEventsResponse } from '../../../types';
+import { IBusinessNotificationResponse } from '../../../notifications';
 
-export const BusinessCreatedMock: IEventsResponse<IBusinessResponse> = {
+export const BusinessCreatedMock: IEventsResponse<IBusinessNotificationResponse> = {
   event_id: 'evt_01h84a7j1cpqtrcdqs63ph1pqe',
   event_type: 'business.created',
   occurred_at: '2023-08-18T12:34:25.964234Z',
@@ -37,6 +38,7 @@ export const BusinessCreatedMockExpectation = {
     customData: {
       customer_reference_id: 'abcd1234',
     },
+    customerId: null,
     id: 'biz_01h84a7hr4pzhsajkm8tev89ev',
     importMeta: null,
     name: 'ChatApp Inc.',

--- a/src/__tests__/mocks/notifications/business-imported.mock.ts
+++ b/src/__tests__/mocks/notifications/business-imported.mock.ts
@@ -4,9 +4,10 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-import { type IEventsResponse, type IBusinessResponse } from '../../../types';
+import { type IEventsResponse } from '../../../types';
+import { IBusinessNotificationResponse } from '../../../notifications';
 
-export const BusinessImportedMock: IEventsResponse<IBusinessResponse> = {
+export const BusinessImportedMock: IEventsResponse<IBusinessNotificationResponse> = {
   event_id: 'evt_01hhvz7k9kekw1wfxw8v8gbqcy',
   event_type: 'business.imported',
   occurred_at: '2023-08-18T12:34:25.964234Z',
@@ -38,6 +39,7 @@ export const BusinessImportedMockExpectation = {
     customData: {
       customer_reference_id: 'abcd1234',
     },
+    customerId: null,
     id: 'biz_01h84a7hr4pzhsajkm8tev89ev',
     importMeta: {
       externalId: '1fc0727f-d3d5-43a0-907a-f3c002535ca0',

--- a/src/__tests__/mocks/notifications/business-updated.mock.ts
+++ b/src/__tests__/mocks/notifications/business-updated.mock.ts
@@ -4,9 +4,10 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-import { type IEventsResponse, type IBusinessResponse } from '../../../types';
+import { type IEventsResponse } from '../../../types';
+import { IBusinessNotificationResponse } from '../../../notifications';
 
-export const BusinessUpdatedMock: IEventsResponse<IBusinessResponse> = {
+export const BusinessUpdatedMock: IEventsResponse<IBusinessNotificationResponse> = {
   event_id: 'evt_01h84b8sq18asjb0m3tvn4g0dn',
   event_type: 'business.updated',
   occurred_at: '2023-08-18T12:52:35.169192Z',
@@ -49,6 +50,7 @@ export const BusinessUpdatedMockExpectation = {
     customData: {
       customer_reference_id: 'abcd1234',
     },
+    customerId: null,
     id: 'biz_01h84a7hr4pzhsajkm8tev89ev',
     importMeta: null,
     name: 'ChatApp Inc.',

--- a/src/__tests__/mocks/resources/addresses.mock.ts
+++ b/src/__tests__/mocks/resources/addresses.mock.ts
@@ -42,6 +42,7 @@ export const UpdateAddressExpectation = {
 
 export const AddressMock: IAddressResponse = {
   id: 'add_01gm302t81w94gyjpjpqypkzkf',
+  customer_id: 'ctm_01grnn4zta5a1mf02jjze7y2ys',
   description: 'Paddle.com',
   first_line: '3811 Ditmars Blvd',
   second_line: 'Suite 671',

--- a/src/__tests__/mocks/resources/businesses.mock.ts
+++ b/src/__tests__/mocks/resources/businesses.mock.ts
@@ -27,6 +27,7 @@ export const UpdateBusinessExpectation = {
 
 export const BusinessMock: IBusinessResponse = {
   id: 'biz_01grrebrzaee2qj2fqqhmcyzaj',
+  customer_id: 'ctm_01grnn4zta5a1mf02jjze7y2ys',
   name: 'Lyda',
   company_number: '123456789',
   tax_identifier: 'AB0123456789',

--- a/src/entities/address/address.ts
+++ b/src/entities/address/address.ts
@@ -10,6 +10,7 @@ import { type IAddressResponse } from '../../types';
 
 export class Address {
   public readonly id: string;
+  public readonly customerId: string;
   public readonly description: string | null;
   public readonly firstLine: string | null;
   public readonly secondLine: string | null;
@@ -25,6 +26,7 @@ export class Address {
 
   constructor(address: IAddressResponse) {
     this.id = address.id;
+    this.customerId = address.customer_id;
     this.description = address.description ? address.description : null;
     this.firstLine = address.first_line ? address.first_line : null;
     this.secondLine = address.second_line ? address.second_line : null;

--- a/src/entities/business/business.ts
+++ b/src/entities/business/business.ts
@@ -10,6 +10,7 @@ import { type IBusinessResponse } from '../../types';
 
 export class Business {
   public readonly id: string;
+  public readonly customerId: string;
   public readonly name: string;
   public readonly companyNumber: string | null;
   public readonly taxIdentifier: string | null;
@@ -22,6 +23,7 @@ export class Business {
 
   constructor(business: IBusinessResponse) {
     this.id = business.id;
+    this.customerId = business.customer_id;
     this.name = business.name;
     this.companyNumber = business.company_number ? business.company_number : null;
     this.taxIdentifier = business.tax_identifier ? business.tax_identifier : null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-export { Environment } from './internal';
+export { Environment, ApiError, type PaddleOptions } from './internal';
 export { SDK_VERSION } from './version';
 
 export { Paddle } from './paddle';

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -1,3 +1,4 @@
 export type { ErrorResponse, ResponsePaginated, Response, ErrorDetail, ErrorField } from './types/response';
 export type { PaddleOptions } from './types/config';
 export * from './api';
+export { ApiError } from './errors/generic';

--- a/src/internal/types/config.ts
+++ b/src/internal/types/config.ts
@@ -1,4 +1,4 @@
-import { type Environment } from '../api/environment';
+import { type Environment } from '../api';
 
 export interface PaddleOptions {
   environment?: Environment;

--- a/src/notifications/entities/address/address-notification.ts
+++ b/src/notifications/entities/address/address-notification.ts
@@ -9,6 +9,7 @@ import { type IAddressNotificationResponse } from '../../types';
 
 export class AddressNotification {
   public readonly id: string;
+  public readonly customerId: string | null;
   public readonly description: string | null;
   public readonly firstLine: string | null;
   public readonly secondLine: string | null;
@@ -24,6 +25,7 @@ export class AddressNotification {
 
   constructor(address: IAddressNotificationResponse) {
     this.id = address.id;
+    this.customerId = address.customer_id ?? null;
     this.description = address.description ? address.description : null;
     this.firstLine = address.first_line ? address.first_line : null;
     this.secondLine = address.second_line ? address.second_line : null;

--- a/src/notifications/entities/business/business-notification.ts
+++ b/src/notifications/entities/business/business-notification.ts
@@ -11,6 +11,7 @@ import { type CustomData } from '../../../entities';
 
 export class BusinessNotification {
   public readonly id: string;
+  public readonly customerId: string | null;
   public readonly name: string;
   public readonly companyNumber: string | null;
   public readonly taxIdentifier: string | null;
@@ -23,6 +24,7 @@ export class BusinessNotification {
 
   constructor(business: IBusinessNotificationResponse) {
     this.id = business.id;
+    this.customerId = business.customer_id ?? null;
     this.name = business.name;
     this.companyNumber = business.company_number ? business.company_number : null;
     this.taxIdentifier = business.tax_identifier ? business.tax_identifier : null;

--- a/src/notifications/types/address/address-notification-response.ts
+++ b/src/notifications/types/address/address-notification-response.ts
@@ -8,6 +8,7 @@ import { type ICustomData, type IImportMetaResponse } from '../../../types';
 
 export interface IAddressNotificationResponse {
   id: string;
+  customer_id?: string | null;
   description?: string | null;
   first_line?: string | null;
   second_line?: string | null;

--- a/src/notifications/types/business/business-notification-response.ts
+++ b/src/notifications/types/business/business-notification-response.ts
@@ -10,6 +10,7 @@ import { type ICustomData } from '../../../types';
 
 export interface IBusinessNotificationResponse {
   id: string;
+  customer_id?: string | null;
   name: string;
   company_number?: string | null;
   tax_identifier?: string | null;

--- a/src/types/address/address-response.ts
+++ b/src/types/address/address-response.ts
@@ -9,6 +9,7 @@ import { type CountryCode, type Status } from '../../enums';
 
 export interface IAddressResponse {
   id: string;
+  customer_id: string;
   description?: string | null;
   first_line?: string | null;
   second_line?: string | null;

--- a/src/types/business/business-response.ts
+++ b/src/types/business/business-response.ts
@@ -9,6 +9,7 @@ import { type Status } from '../../enums';
 
 export interface IBusinessResponse {
   id: string;
+  customer_id: string;
   name: string;
   company_number?: string | null;
   tax_identifier?: string | null;


### PR DESCRIPTION
## 1.0.2 - 2024-03-12

### Added

- Exported `ApiError` class for usage in `try/catch` block.

### Changed

- Added `customerId` property to `Address` and `Business` entities.

---

Fixes: #7 