### PR TITLE
Updated `ErrorCode` enum in `TransactionPaymentAttempt` to include a new error code `declined_not_retryable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ When we make [non-breaking changes](https://developer.paddle.com/api-reference/a
 
 This means when upgrading minor versions of the SDK, you may notice type errors. You can safely ignore these or fix by adding additional type guards.
 
+## 1.1.1 - 2024-03-19
+
+### Changed
+
+- Updated `ErrorCode` enum in `TransactionPaymentAttempt` to include a new error code `declined_not_retryable`
+
+---
 
 ## 1.1.0 - 2024-03-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ When we make [non-breaking changes](https://developer.paddle.com/api-reference/a
 
 This means when upgrading minor versions of the SDK, you may notice type errors. You can safely ignore these or fix by adding additional type guards.
 
-## 1.1.1 - 2024-03-19
+## 1.2.0 - 2024-03-19
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-node-sdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A Node.js SDK that you can use to integrate Paddle Billing with applications written in server-side JavaScript.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-node-sdk",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A Node.js SDK that you can use to integrate Paddle Billing with applications written in server-side JavaScript.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/enums/shared/error-code.ts
+++ b/src/enums/shared/error-code.ts
@@ -11,6 +11,7 @@ export type ErrorCode =
   | 'blocked_card'
   | 'canceled'
   | 'declined'
+  | 'declined_not_retryable'
   | 'expired_card'
   | 'fraud'
   | 'invalid_amount'


### PR DESCRIPTION
## 1.2.0 - 2024-03-19

### Changed

- Updated `ErrorCode` enum in `TransactionPaymentAttempt` to include a new error code `declined_not_retryable`

---