### PR TITLE
Handled missing `unitPriceOverrides` in the `subscriptions.getPaymentMethodChangeTransaction` operation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ When we make [non-breaking changes](https://developer.paddle.com/api-reference/a
 
 This means when upgrading minor versions of the SDK, you may notice type errors. You can safely ignore these or fix by adding additional type guards.
 
+## 1.2.1 - 2024-03-20
+
+### Fixed
+
+- Handled missing `unitPriceOverrides` in the `subscriptions.getPaymentMethodChangeTransaction` operation.
+
+---
+
 ## 1.2.0 - 2024-03-19
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-node-sdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A Node.js SDK that you can use to integrate Paddle Billing with applications written in server-side JavaScript.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/entities/price/price.ts
+++ b/src/entities/price/price.ts
@@ -37,9 +37,8 @@ export class Price {
     this.trialPeriod = price.trial_period ? new TimePeriod(price.trial_period) : null;
     this.taxMode = price.tax_mode;
     this.unitPrice = new Money(price.unit_price);
-    this.unitPriceOverrides = price.unit_price_overrides.map(
-      (unit_price_override) => new UnitPriceOverride(unit_price_override),
-    );
+    this.unitPriceOverrides =
+      price.unit_price_overrides?.map((unit_price_override) => new UnitPriceOverride(unit_price_override)) ?? [];
     this.quantity = new PriceQuantity(price.quantity);
     this.status = price.status;
     this.createdAt = price.created_at;

--- a/src/notifications/entities/price/price-notification.ts
+++ b/src/notifications/entities/price/price-notification.ts
@@ -43,9 +43,10 @@ export class PriceNotification {
     this.trialPeriod = price.trial_period ? new TimePeriodNotification(price.trial_period) : null;
     this.taxMode = price.tax_mode;
     this.unitPrice = new MoneyNotification(price.unit_price);
-    this.unitPriceOverrides = price.unit_price_overrides.map(
-      (unit_price_override) => new UnitPriceOverrideNotification(unit_price_override),
-    );
+    this.unitPriceOverrides =
+      price.unit_price_overrides?.map(
+        (unit_price_override) => new UnitPriceOverrideNotification(unit_price_override),
+      ) ?? [];
     this.quantity = new PriceQuantityNotification(price.quantity);
     this.status = price.status;
     this.createdAt = price.created_at ?? null;

--- a/src/notifications/types/price/price-notification-response.ts
+++ b/src/notifications/types/price/price-notification-response.ts
@@ -25,7 +25,7 @@ export interface IPriceNotificationResponse {
   trial_period?: ITimePeriodNotification | null;
   tax_mode: TaxMode;
   unit_price: IMoneyNotificationResponse;
-  unit_price_overrides: IUnitPriceOverrideNotificationResponse[];
+  unit_price_overrides: IUnitPriceOverrideNotificationResponse[] | null;
   quantity: IPriceQuantityNotification;
   status: Status;
   created_at?: string | null;

--- a/src/types/price/price-response.ts
+++ b/src/types/price/price-response.ts
@@ -25,7 +25,7 @@ export interface IPriceResponse {
   trial_period?: ITimePeriod | null;
   tax_mode: TaxMode;
   unit_price: IMoneyResponse;
-  unit_price_overrides: IUnitPriceOverrideResponse[];
+  unit_price_overrides: IUnitPriceOverrideResponse[] | null;
   quantity: IPriceQuantity;
   status: Status;
   created_at: string;


### PR DESCRIPTION
## 1.2.1 - 2024-03-20

### Fixed

- Handled missing `unitPriceOverrides` in the `subscriptions.getPaymentMethodChangeTransaction` operation.

---

Fixes: #18 