### PR TITLE
Updated the optional properties in Pricing preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ When we make [non-breaking changes](https://developer.paddle.com/api-reference/a
 
 This means when upgrading minor versions of the SDK, you may notice type errors. You can safely ignore these or fix by adding additional type guards.
 
+## 1.2.2 - 2024-04-03
+
+### Fixed
+
+- Updated the optional properties returned by `pricingPreview.preview` operation to match the API response.
+
+---
+
 ## 1.2.1 - 2024-03-20
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-node-sdk",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A Node.js SDK that you can use to integrate Paddle Billing with applications written in server-side JavaScript.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/__tests__/mocks/resources/pricing-preview.mock.ts
+++ b/src/__tests__/mocks/resources/pricing-preview.mock.ts
@@ -18,7 +18,7 @@ export const PricingPreviewRequest: PricingPreviewRequestBody = {
   ],
 };
 export const PricingPreviewMock: IPricingPreviewResponse = {
-  available_payment_method: 'apple_pay',
+  available_payment_methods: ['apple_pay'],
   currency_code: 'USD',
   address: {
     country_code: 'US',

--- a/src/entities/pricing-preview/pricing-preview.ts
+++ b/src/entities/pricing-preview/pricing-preview.ts
@@ -13,22 +13,22 @@ export class PricingPreview {
   public readonly customerId: string | null;
   public readonly addressId: string | null;
   public readonly businessId: string | null;
-  public readonly currencyCode: CurrencyCode | null;
+  public readonly currencyCode: CurrencyCode;
   public readonly discountId: string | null;
   public readonly address: AddressPreview | null;
   public readonly customerIpAddress: string | null;
-  public readonly details: PricingPreviewDetails | null;
-  public readonly availablePaymentMethods: AvailablePaymentMethod | null;
+  public readonly details: PricingPreviewDetails;
+  public readonly availablePaymentMethods: AvailablePaymentMethod[];
 
   constructor(pricePreview: IPricingPreviewResponse) {
     this.customerId = pricePreview.customer_id ?? null;
     this.addressId = pricePreview.address_id ?? null;
     this.businessId = pricePreview.business_id ?? null;
-    this.currencyCode = pricePreview.currency_code ?? null;
+    this.currencyCode = pricePreview.currency_code;
     this.discountId = pricePreview.discount_id ?? null;
     this.address = pricePreview.address ? new AddressPreview(pricePreview.address) : null;
     this.customerIpAddress = pricePreview.customer_ip_address ?? null;
-    this.details = pricePreview.details ? new PricingPreviewDetails(pricePreview.details) : null;
-    this.availablePaymentMethods = pricePreview.available_payment_method ?? null;
+    this.details = new PricingPreviewDetails(pricePreview.details);
+    this.availablePaymentMethods = pricePreview.available_payment_methods ?? [];
   }
 }

--- a/src/types/pricing-preview/pricing-preview-response.ts
+++ b/src/types/pricing-preview/pricing-preview-response.ts
@@ -13,11 +13,11 @@ export interface IPricingPreviewResponse {
   customer_id?: string | null;
   address_id?: string | null;
   business_id?: string | null;
-  currency_code?: CurrencyCode | null;
+  currency_code: CurrencyCode;
   discount_id?: string | null;
   address?: IAddressPreviewResponse | null;
   customer_ip_address?: string | null;
   items: IPricingPreviewItemResponse[];
-  details?: IPricingPreviewDetailsResponse | null;
-  available_payment_method?: AvailablePaymentMethod | null;
+  details: IPricingPreviewDetailsResponse;
+  available_payment_methods: AvailablePaymentMethod[];
 }


### PR DESCRIPTION
## 1.2.2 - 2024-04-03

### Fixed

- Updated the optional properties returned by `pricingPreview.preview` operation to match the API response.

---