### PR TITLE
feat(logs): Added an option to control log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ When we make [non-breaking changes](https://developer.paddle.com/api-reference/a
 
 This means when upgrading minor versions of the SDK, you may notice type errors. You can safely ignore these or fix by adding additional type guards.
 
+## 1.4.0 - 2024-06-20
+
+### Added
+
+- Added a new option to change the logging level of the SDK. You can now set the logging level to `verbose`, `warn`, `error` or `none`. The default logging level is `verbose`.
+
+---
+
 ## 1.3.0 - 2024-04-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ You can also pass an environment to work with the sandbox:
 ```typescript
 const paddle = new Paddle('API_KEY', {
   environment: Environment.production, // or Environment.sandbox for accessing sandbox API
+  logLevel: 'verbose' // or 'error' for less verbose logging
 })
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-node-sdk",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A Node.js SDK that you can use to integrate Paddle Billing with applications written in server-side JavaScript.",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/__tests__/internal/logger.test.ts
+++ b/src/__tests__/internal/logger.test.ts
@@ -28,7 +28,7 @@ describe('logger', () => {
     // @ts-expect-error - testing private method
     expect(Logger.shouldLog(level)).toBe(expected);
   });
-  test('log', () => {
+  test('verbose', () => {
     Logger.logLevel = LogLevel.verbose;
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
     Logger.log('test');
@@ -78,5 +78,23 @@ describe('logger', () => {
       'Request ID:',
       '456',
     );
+  });
+  test('verbose is not logged when log level is warn', () => {
+    Logger.logLevel = LogLevel.warn;
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    Logger.log('test');
+    expect(consoleSpy).not.toHaveBeenCalledWith('[Paddle] [LOG]', 'test');
+  });
+  test('warning is not logged when log level is error', () => {
+    Logger.logLevel = LogLevel.error;
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+    Logger.warn('test');
+    expect(consoleSpy).not.toHaveBeenCalledWith('[Paddle] [WARN]', 'test');
+  });
+  test('error is not logged when log level is none', () => {
+    Logger.logLevel = LogLevel.none;
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+    Logger.error('test');
+    expect(consoleSpy).not.toHaveBeenCalledWith('[Paddle] [ERROR]', 'test');
   });
 });

--- a/src/__tests__/internal/logger.test.ts
+++ b/src/__tests__/internal/logger.test.ts
@@ -1,0 +1,82 @@
+import { LogLevel } from '../../internal';
+import { Logger } from '../../internal/base/logger';
+import { type Response } from 'node-fetch';
+
+describe('logger', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+  test.each([
+    [LogLevel.verbose, LogLevel.verbose, true],
+    [LogLevel.verbose, LogLevel.warn, true],
+    [LogLevel.verbose, LogLevel.error, true],
+    [LogLevel.verbose, LogLevel.none, false],
+    [LogLevel.warn, LogLevel.verbose, false],
+    [LogLevel.warn, LogLevel.warn, true],
+    [LogLevel.warn, LogLevel.error, true],
+    [LogLevel.warn, LogLevel.none, false],
+    [LogLevel.error, LogLevel.verbose, false],
+    [LogLevel.error, LogLevel.warn, false],
+    [LogLevel.error, LogLevel.error, true],
+    [LogLevel.error, LogLevel.none, false],
+    [LogLevel.none, LogLevel.verbose, false],
+    [LogLevel.none, LogLevel.warn, false],
+    [LogLevel.none, LogLevel.error, false],
+    [LogLevel.none, LogLevel.none, false],
+  ])('shouldLog(%s) with logLevel %s should return %s', (logLevel, level, expected) => {
+    Logger.logLevel = logLevel;
+    // @ts-expect-error - testing private method
+    expect(Logger.shouldLog(level)).toBe(expected);
+  });
+  test('log', () => {
+    Logger.logLevel = LogLevel.verbose;
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    Logger.log('test');
+    expect(consoleSpy).toHaveBeenCalledWith('[Paddle] [LOG]', 'test');
+  });
+  test('warn', () => {
+    Logger.logLevel = LogLevel.warn;
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+    Logger.warn('test');
+    expect(consoleSpy).toHaveBeenCalledWith('[Paddle] [WARN]', 'test');
+  });
+  test('error', () => {
+    Logger.logLevel = LogLevel.error;
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+    Logger.error('test');
+    expect(consoleSpy).toHaveBeenCalledWith('[Paddle] [ERROR]', 'test');
+  });
+  test('logRequest', () => {
+    Logger.logLevel = LogLevel.verbose;
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    Logger.logRequest('GET', 'https://example.com', { 'X-Transaction-ID': '123' });
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[Paddle] [LOG]',
+      '[Request]',
+      'GET',
+      'https://example.com',
+      'Transaction ID:',
+      '123',
+    );
+  });
+  test('logResponse', () => {
+    Logger.logLevel = LogLevel.verbose;
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    const response = {
+      status: 200,
+      headers: new Map([['Request-Id', '456']]),
+    };
+    Logger.logResponse('GET', 'https://example.com', { 'X-Transaction-ID': '123' }, response as unknown as Response);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[Paddle] [LOG]',
+      '[Response]',
+      'GET',
+      'https://example.com',
+      '200',
+      'Transaction ID:',
+      '123',
+      'Request ID:',
+      '456',
+    );
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-export { Environment, ApiError, type PaddleOptions } from './internal';
+export { Environment, LogLevel, ApiError, type PaddleOptions } from './internal';
 export { SDK_VERSION } from './version';
 
 export { Paddle } from './paddle';

--- a/src/internal/api/client.ts
+++ b/src/internal/api/client.ts
@@ -8,6 +8,7 @@ import { randomUUID } from 'node:crypto';
 import { Logger } from '../base/logger';
 import { convertToSnakeCase } from './case-helpers';
 import { type ErrorResponse } from '../types/response';
+import { LogLevel } from './log-level';
 
 export class Client {
   private readonly baseUrl: string;
@@ -17,6 +18,8 @@ export class Client {
     private readonly options: PaddleOptions,
   ) {
     this.baseUrl = this.getBaseUrl(this.options.environment);
+    // TODO - Change the default to `error` in next major version
+    Logger.logLevel = this.options.logLevel ?? LogLevel.verbose;
   }
 
   private getBaseUrl(environment?: Environment): string {

--- a/src/internal/api/index.ts
+++ b/src/internal/api/index.ts
@@ -1,2 +1,3 @@
 export { Environment } from './environment';
 export { convertToSnakeCase } from './case-helpers';
+export { LogLevel } from './log-level';

--- a/src/internal/api/log-level.ts
+++ b/src/internal/api/log-level.ts
@@ -1,0 +1,6 @@
+export enum LogLevel {
+  verbose = 'verbose',
+  warn = 'warn',
+  error = 'error',
+  none = 'none',
+}

--- a/src/internal/base/logger.ts
+++ b/src/internal/base/logger.ts
@@ -1,18 +1,39 @@
 import { type Response } from 'node-fetch';
+import { LogLevel } from '../api';
 
 type LogInputProps = Array<string | undefined | null>;
 
 export class Logger {
+  static logLevel: LogLevel;
+
+  private static shouldLog(level: LogLevel) {
+    switch (Logger.logLevel) {
+      case LogLevel.verbose:
+        return level !== LogLevel.none;
+      case LogLevel.warn:
+        return level === LogLevel.warn || level === LogLevel.error;
+      case LogLevel.error:
+        return level === LogLevel.error;
+      default:
+        return false;
+    }
+  }
   static log(...args: LogInputProps) {
-    console.log('[Paddle] [LOG]', ...args);
+    if (Logger.shouldLog(LogLevel.verbose)) {
+      console.log('[Paddle] [LOG]', ...args);
+    }
   }
 
   static warn(...args: LogInputProps) {
-    console.warn('[Paddle] [WARN]', ...args);
+    if (Logger.shouldLog(LogLevel.warn)) {
+      console.warn('[Paddle] [WARN]', ...args);
+    }
   }
 
   static error(...args: LogInputProps) {
-    console.error('[Paddle] [ERROR]', ...args);
+    if (Logger.shouldLog(LogLevel.error)) {
+      console.error('[Paddle] [ERROR]', ...args);
+    }
   }
 
   static logRequest(method: string, url: string | undefined, headers: Record<string, string>) {

--- a/src/internal/base/logger.ts
+++ b/src/internal/base/logger.ts
@@ -18,6 +18,7 @@ export class Logger {
         return false;
     }
   }
+
   static log(...args: LogInputProps) {
     if (Logger.shouldLog(LogLevel.verbose)) {
       console.log('[Paddle] [LOG]', ...args);

--- a/src/internal/types/config.ts
+++ b/src/internal/types/config.ts
@@ -1,4 +1,4 @@
-import { type Environment, LogLevel } from '../api';
+import { type Environment, type LogLevel } from '../api';
 
 export interface PaddleOptions {
   environment?: Environment;

--- a/src/internal/types/config.ts
+++ b/src/internal/types/config.ts
@@ -1,5 +1,6 @@
-import { type Environment } from '../api';
+import { type Environment, LogLevel } from '../api';
 
 export interface PaddleOptions {
   environment?: Environment;
+  logLevel?: LogLevel;
 }

--- a/src/paddle.ts
+++ b/src/paddle.ts
@@ -15,7 +15,7 @@ import {
   SubscriptionsResource,
   TransactionsResource,
 } from './resources';
-import { Environment, type PaddleOptions } from './internal';
+import { Environment, LogLevel, type PaddleOptions } from './internal';
 import { EventsResource } from './resources/events';
 import { Webhooks } from './notifications';
 
@@ -23,6 +23,7 @@ export class Paddle {
   private readonly client: Client;
   private readonly defaultPaddleOptions: Partial<PaddleOptions> = {
     environment: Environment.production,
+    logLevel: LogLevel.verbose, // TODO - Change the default to `error` in next major version
   };
 
   public products: ProductsResource;


### PR DESCRIPTION
## 1.4.0 - 2024-06-20

### Added

- Added a new option to change the logging level of the SDK. You can now set the logging level to `verbose`, `warn`, `error` or `none`. The default logging level is `verbose`.

---

Fixes: #8 