### PR TITLE
fix(Transaction): Marked `paymentMethodId` as nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ When we make [non-breaking changes](https://developer.paddle.com/api-reference/a
 
 This means when upgrading minor versions of the SDK, you may notice type errors. You can safely ignore these or fix by adding additional type guards.
 
+## 1.7.0 - 2024-09-18
+
+### Fixed
+
+- Marked `paymentMethodId` as nullable in `TransactionPaymentAttempt` as it can be `null`.
+
+---
+
 ## 1.6.0 - 2024-09-16
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-node-sdk",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "A Node.js SDK that you can use to integrate Paddle Billing with applications written in server-side JavaScript.",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/entities/shared/transaction-payment-attempt.ts
+++ b/src/entities/shared/transaction-payment-attempt.ts
@@ -10,7 +10,7 @@ import { type PaymentAttemptStatus, type ErrorCode } from '../../enums';
 
 export class TransactionPaymentAttempt {
   public readonly paymentAttemptId: string;
-  public readonly paymentMethodId: string;
+  public readonly paymentMethodId: string | null;
   /**
    * @deprecated use paymentMethodId instead
    */
@@ -24,7 +24,7 @@ export class TransactionPaymentAttempt {
 
   constructor(transactionPaymentAttempt: ITransactionPaymentAttemptResponse) {
     this.paymentAttemptId = transactionPaymentAttempt.payment_attempt_id;
-    this.paymentMethodId = transactionPaymentAttempt.payment_method_id;
+    this.paymentMethodId = transactionPaymentAttempt.payment_method_id ?? null;
     this.storedPaymentMethodId = transactionPaymentAttempt.stored_payment_method_id;
     this.amount = transactionPaymentAttempt.amount;
     this.status = transactionPaymentAttempt.status;

--- a/src/types/shared/transaction-payment-attempt-response.ts
+++ b/src/types/shared/transaction-payment-attempt-response.ts
@@ -13,7 +13,7 @@ export interface ITransactionPaymentAttemptResponse {
    * @deprecated use payment_method_id instead
    */
   stored_payment_method_id: string;
-  payment_method_id: string;
+  payment_method_id: string | null;
   amount: string;
   status: PaymentAttemptStatus;
   error_code?: ErrorCode | null;


### PR DESCRIPTION
## 1.7.0 - 2024-09-18

### Fixed

- Marked `paymentMethodId` as nullable in `TransactionPaymentAttempt` as it can be `null`.

---