### PR TITLE
Infer simulation payload

### DIFF
--- a/src/__tests__/mocks/resources/simulations.mock.ts
+++ b/src/__tests__/mocks/resources/simulations.mock.ts
@@ -8,7 +8,7 @@ import { ISimulationResponse } from '../../../types';
 import { Response, ResponsePaginated } from '../../../internal';
 import { CreateSimulationRequestBody, UpdateSimulationRequestBody } from '../../../resources';
 
-export const CreateSimulationMock: CreateSimulationRequestBody = {
+export const CreateSimulationMock: CreateSimulationRequestBody<'address.created'> = {
   notificationSettingId: 'ntfset_01gt21c5pdx9q1e4mh1xrsjjn6',
   type: 'address.created',
   name: 'New address created',
@@ -18,7 +18,7 @@ export const updateSimulationMock: UpdateSimulationRequestBody = {
   name: 'New UK address created',
 };
 
-export const SimulationMock: ISimulationResponse = {
+export const SimulationMock: ISimulationResponse<'address.created'> = {
   id: 'ntfsim_01ghbkd0frb9k95cnhwd1bxpvk',
   status: 'active',
   notification_setting_id: 'ntfset_01gt21c5pdx9q1e4mh1xrsjjn6',
@@ -30,14 +30,14 @@ export const SimulationMock: ISimulationResponse = {
   updated_at: '2024-10-13T07:20:50.52Z',
 };
 
-export const SimulationMockResponse: Response<ISimulationResponse> = {
+export const SimulationMockResponse: Response<ISimulationResponse<'address.created'>> = {
   data: SimulationMock,
   meta: {
     request_id: '',
   },
 };
 
-export const ListSimulationMockResponse: ResponsePaginated<ISimulationResponse> = {
+export const ListSimulationMockResponse: ResponsePaginated<ISimulationResponse<'address.created'>> = {
   data: [SimulationMock],
   meta: {
     request_id: '',

--- a/src/__tests__/resources/simulations.test.ts
+++ b/src/__tests__/resources/simulations.test.ts
@@ -80,7 +80,7 @@ describe('SimulationsResource', () => {
   });
 
   test('should create a new simulation', async () => {
-    const newSimulation: CreateSimulationRequestBody = CreateSimulationMock;
+    const newSimulation: CreateSimulationRequestBody<'address.created'> = CreateSimulationMock;
     const paddleInstance = getPaddleTestClient();
 
     paddleInstance.post = jest.fn().mockResolvedValue(SimulationMockResponse);

--- a/src/entities/simulation-run-event/simulation-run-event.ts
+++ b/src/entities/simulation-run-event/simulation-run-event.ts
@@ -4,15 +4,14 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-import type { SimulationRunEventStatus, SimulationScenarioType } from '../../enums';
-import type { IEventName } from '../../notifications';
+import type { SimulationRunEventStatus, SimulationEventType } from '../../enums';
 import type { ISimulationRunEventResponse } from '../../types';
 import { SimulationEventRequest, SimulationEventResponse } from '../shared';
 
 export class SimulationRunEvent {
   public readonly id: string;
   public readonly status: SimulationRunEventStatus;
-  public readonly eventType: IEventName | SimulationScenarioType;
+  public readonly eventType: SimulationEventType;
   public readonly payload: any;
   public readonly request: SimulationEventRequest | null;
   public readonly response: SimulationEventResponse | null;

--- a/src/entities/simulation-run/simulation-run.ts
+++ b/src/entities/simulation-run/simulation-run.ts
@@ -4,17 +4,16 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-import type { SimulationRunStatus, SimulationScenarioType } from '../../enums';
-import type { IEventName } from '../../notifications';
-import type { ISimulationRunResponse } from '../../types';
 import { SimulationRunEvent } from '..';
+import type { SimulationRunStatus, SimulationEventType } from '../../enums';
+import type { ISimulationRunResponse } from '../../types';
 
 export class SimulationRun {
   public readonly id: string;
   public readonly status: SimulationRunStatus;
   public readonly createdAt: string;
   public readonly updatedAt: string;
-  public readonly type: IEventName | SimulationScenarioType;
+  public readonly type: SimulationEventType;
   public readonly events: SimulationRunEvent[] | null;
 
   constructor(simulationRunResponse: ISimulationRunResponse) {

--- a/src/entities/simulation/simulation-collection.ts
+++ b/src/entities/simulation/simulation-collection.ts
@@ -7,9 +7,14 @@
 import { Simulation } from '../../entities';
 import { type ISimulationResponse } from '../../types';
 import { Collection } from '../../internal/base';
+import type { IEventName } from '../../notifications';
+import type { SimulationScenarioType } from '../../enums';
 
-export class SimulationCollection extends Collection<ISimulationResponse, Simulation> {
-  override fromJson(data: ISimulationResponse): Simulation {
+export class SimulationCollection<T extends IEventName | SimulationScenarioType> extends Collection<
+  ISimulationResponse<T>,
+  Simulation<T>
+> {
+  override fromJson(data: ISimulationResponse<T>): Simulation<T> {
     return new Simulation(data);
   }
 }

--- a/src/entities/simulation/simulation-collection.ts
+++ b/src/entities/simulation/simulation-collection.ts
@@ -7,14 +7,13 @@
 import { Simulation } from '../../entities';
 import { type ISimulationResponse } from '../../types';
 import { Collection } from '../../internal/base';
-import type { IEventName } from '../../notifications';
-import type { SimulationScenarioType } from '../../enums';
+import type { SimulationEventType } from '../../enums';
 
-export class SimulationCollection<T extends IEventName | SimulationScenarioType> extends Collection<
-  ISimulationResponse<T>,
-  Simulation<T>
+export class SimulationCollection extends Collection<
+  ISimulationResponse<SimulationEventType>,
+  Simulation<SimulationEventType>
 > {
-  override fromJson(data: ISimulationResponse<T>): Simulation<T> {
+  override fromJson(data: ISimulationResponse<SimulationEventType>): Simulation<SimulationEventType> {
     return new Simulation(data);
   }
 }

--- a/src/entities/simulation/simulation.ts
+++ b/src/entities/simulation/simulation.ts
@@ -5,10 +5,10 @@
  */
 
 import { type ISimulationResponse } from '../../types';
-import type { SimulationScenarioType, Status } from '../../enums';
+import type { SimulationEventType, Status } from '../../enums';
 import type { EventMap, IEventName } from '../../notifications';
 
-export class Simulation<T extends IEventName | SimulationScenarioType> {
+export class Simulation<T extends SimulationEventType | undefined = undefined> {
   public readonly id: string;
   public readonly status: Status;
   public readonly notificationSettingId: string;

--- a/src/entities/simulation/simulation.ts
+++ b/src/entities/simulation/simulation.ts
@@ -6,20 +6,20 @@
 
 import { type ISimulationResponse } from '../../types';
 import type { SimulationScenarioType, Status } from '../../enums';
-import type { IEventName } from '../../notifications';
+import type { EventMap, IEventName } from '../../notifications';
 
-export class Simulation {
+export class Simulation<T extends IEventName | SimulationScenarioType> {
   public readonly id: string;
   public readonly status: Status;
   public readonly notificationSettingId: string;
   public readonly name: string;
-  public readonly type: IEventName | SimulationScenarioType;
-  public readonly payload: any;
+  public readonly type: T;
+  public readonly payload: (T extends IEventName ? EventMap[T] : null) | null;
   public readonly lastRunAt: string | null;
   public readonly createdAt: string;
   public readonly updatedAt: string;
 
-  constructor(simulationResponse: ISimulationResponse) {
+  constructor(simulationResponse: ISimulationResponse<T>) {
     this.id = simulationResponse.id;
     this.status = simulationResponse.status;
     this.notificationSettingId = simulationResponse.notification_setting_id;

--- a/src/enums/simulation/index.ts
+++ b/src/enums/simulation/index.ts
@@ -4,4 +4,5 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
+export * from './simulation-type';
 export * from './simulation-scenario-type';

--- a/src/enums/simulation/simulation-type.ts
+++ b/src/enums/simulation/simulation-type.ts
@@ -1,0 +1,4 @@
+import type { IEventName } from '../../notifications';
+import type { SimulationScenarioType } from './';
+
+export type SimulationEventType = IEventName | SimulationScenarioType;

--- a/src/notifications/helpers/types.ts
+++ b/src/notifications/helpers/types.ts
@@ -131,6 +131,7 @@ export enum EventName {
   ReportCreated = 'report.created',
   ReportUpdated = 'report.updated',
 }
+
 export type IEventName =
   | 'address.created'
   | 'address.updated'
@@ -175,3 +176,51 @@ export type IEventName =
   | 'transaction.updated'
   | 'report.created'
   | 'report.updated';
+
+export interface EventDataMap extends Record<IEventName, EventEntity> {
+  'address.created': AddressCreatedEvent;
+  'address.updated': AddressUpdatedEvent;
+  'address.imported': AddressImportedEvent;
+  'adjustment.created': AdjustmentCreatedEvent;
+  'adjustment.updated': AdjustmentUpdatedEvent;
+  'business.created': BusinessCreatedEvent;
+  'business.updated': BusinessUpdatedEvent;
+  'business.imported': BusinessImportedEvent;
+  'customer.created': CustomerCreatedEvent;
+  'customer.updated': CustomerUpdatedEvent;
+  'customer.imported': CustomerImportedEvent;
+  'discount.created': DiscountCreatedEvent;
+  'discount.updated': DiscountUpdatedEvent;
+  'discount.imported': DiscountImportedEvent;
+  'payout.created': PayoutCreatedEvent;
+  'payout.paid': PayoutPaidEvent;
+  'price.created': PriceCreatedEvent;
+  'price.updated': PriceUpdatedEvent;
+  'price.imported': PriceImportedEvent;
+  'product.created': ProductCreatedEvent;
+  'product.updated': ProductUpdatedEvent;
+  'product.imported': ProductImportedEvent;
+  'subscription.created': SubscriptionCreatedEvent;
+  'subscription.activated': SubscriptionActivatedEvent;
+  'subscription.canceled': SubscriptionCanceledEvent;
+  'subscription.imported': SubscriptionImportedEvent;
+  'subscription.paused': SubscriptionPausedEvent;
+  'subscription.resumed': SubscriptionResumedEvent;
+  'subscription.trialing': SubscriptionTrialingEvent;
+  'subscription.updated': SubscriptionUpdatedEvent;
+  'transaction.billed': TransactionBilledEvent;
+  'transaction.canceled': TransactionCanceledEvent;
+  'transaction.completed': TransactionCompletedEvent;
+  'transaction.created': TransactionCreatedEvent;
+  'transaction.paid': TransactionPaidEvent;
+  'transaction.past_due': TransactionPastDueEvent;
+  'transaction.payment_failed': TransactionPaymentFailedEvent;
+  'transaction.ready': TransactionReadyEvent;
+  'transaction.updated': TransactionUpdatedEvent;
+  'report.created': ReportCreatedEvent;
+  'report.updated': ReportUpdatedEvent;
+}
+
+export type EventMap = {
+  [K in keyof EventDataMap]: EventDataMap[K] extends { data: infer D } ? Partial<D> : never;
+};

--- a/src/resources/simulations/index.ts
+++ b/src/resources/simulations/index.ts
@@ -26,9 +26,7 @@ const SimulationPaths = {
 } as const;
 
 export class SimulationsResource extends BaseResource {
-  public list<T extends IEventName | SimulationScenarioType>(
-    queryParams?: ListSimulationQueryParameters,
-  ): SimulationCollection<T> {
+  public list(queryParams?: ListSimulationQueryParameters): SimulationCollection<IEventName | SimulationScenarioType> {
     const queryParameters = new QueryParameters(queryParams);
     return new SimulationCollection(this.client, SimulationPaths.list + queryParameters.toQueryString());
   }
@@ -62,14 +60,14 @@ export class SimulationsResource extends BaseResource {
 
   public async update<T extends IEventName | SimulationScenarioType>(
     simulationId: string,
-    updateSimulation: UpdateSimulationRequestBody,
+    updateSimulation: UpdateSimulationRequestBody<T>,
   ): Promise<Simulation<T>> {
     const urlWithPathParams = new PathParameters(SimulationPaths.update, {
       simulation_id: simulationId,
     }).deriveUrl();
 
     const response = await this.client.patch<
-      UpdateSimulationRequestBody,
+      UpdateSimulationRequestBody<T>,
       Response<ISimulationResponse<T>> | ErrorResponse
     >(urlWithPathParams, updateSimulation);
 

--- a/src/resources/simulations/index.ts
+++ b/src/resources/simulations/index.ts
@@ -5,8 +5,10 @@
  */
 
 import { Simulation, SimulationCollection } from '../../entities';
+import type { SimulationScenarioType } from '../../enums';
 import { type ErrorResponse, type Response } from '../../internal';
 import { BaseResource, PathParameters, QueryParameters } from '../../internal/base';
+import type { IEventName } from '../../notifications';
 import { type ISimulationResponse } from '../../types';
 import {
   type CreateSimulationRequestBody,
@@ -24,45 +26,54 @@ const SimulationPaths = {
 } as const;
 
 export class SimulationsResource extends BaseResource {
-  public list(queryParams?: ListSimulationQueryParameters): SimulationCollection {
+  public list<T extends IEventName | SimulationScenarioType>(
+    queryParams?: ListSimulationQueryParameters,
+  ): SimulationCollection<T> {
     const queryParameters = new QueryParameters(queryParams);
     return new SimulationCollection(this.client, SimulationPaths.list + queryParameters.toQueryString());
   }
 
-  public async create(createSimulationParameters: CreateSimulationRequestBody): Promise<Simulation> {
-    const response = await this.client.post<CreateSimulationRequestBody, Response<ISimulationResponse> | ErrorResponse>(
-      SimulationPaths.create,
-      createSimulationParameters,
-    );
+  public async create<T extends IEventName | SimulationScenarioType>(
+    createSimulationParameters: CreateSimulationRequestBody<T>,
+  ): Promise<Simulation<T>> {
+    const response = await this.client.post<
+      CreateSimulationRequestBody<T>,
+      Response<ISimulationResponse<T>> | ErrorResponse
+    >(SimulationPaths.create, createSimulationParameters);
 
-    const data = this.handleResponse<ISimulationResponse>(response);
+    const data = this.handleResponse<ISimulationResponse<T>>(response);
 
     return new Simulation(data);
   }
 
-  public async get(simulationId: string): Promise<Simulation> {
+  public async get<T extends IEventName | SimulationScenarioType>(simulationId: string): Promise<Simulation<T>> {
     const urlWithPathParams = new PathParameters(SimulationPaths.get, {
       simulation_id: simulationId,
     }).deriveUrl();
 
-    const response = await this.client.get<undefined, Response<ISimulationResponse> | ErrorResponse>(urlWithPathParams);
+    const response = await this.client.get<undefined, Response<ISimulationResponse<T>> | ErrorResponse>(
+      urlWithPathParams,
+    );
 
-    const data = this.handleResponse<ISimulationResponse>(response);
+    const data = this.handleResponse<ISimulationResponse<T>>(response);
 
     return new Simulation(data);
   }
 
-  public async update(simulationId: string, updateSimulation: UpdateSimulationRequestBody): Promise<Simulation> {
+  public async update<T extends IEventName | SimulationScenarioType>(
+    simulationId: string,
+    updateSimulation: UpdateSimulationRequestBody,
+  ): Promise<Simulation<T>> {
     const urlWithPathParams = new PathParameters(SimulationPaths.update, {
       simulation_id: simulationId,
     }).deriveUrl();
 
     const response = await this.client.patch<
       UpdateSimulationRequestBody,
-      Response<ISimulationResponse> | ErrorResponse
+      Response<ISimulationResponse<T>> | ErrorResponse
     >(urlWithPathParams, updateSimulation);
 
-    const data = this.handleResponse<ISimulationResponse>(response);
+    const data = this.handleResponse<ISimulationResponse<T>>(response);
 
     return new Simulation(data);
   }

--- a/src/resources/simulations/index.ts
+++ b/src/resources/simulations/index.ts
@@ -5,10 +5,9 @@
  */
 
 import { Simulation, SimulationCollection } from '../../entities';
-import type { SimulationScenarioType } from '../../enums';
+import type { SimulationEventType } from '../../enums';
 import { type ErrorResponse, type Response } from '../../internal';
 import { BaseResource, PathParameters, QueryParameters } from '../../internal/base';
-import type { IEventName } from '../../notifications';
 import { type ISimulationResponse } from '../../types';
 import {
   type CreateSimulationRequestBody,
@@ -26,12 +25,12 @@ const SimulationPaths = {
 } as const;
 
 export class SimulationsResource extends BaseResource {
-  public list(queryParams?: ListSimulationQueryParameters): SimulationCollection<IEventName | SimulationScenarioType> {
+  public list(queryParams?: ListSimulationQueryParameters): SimulationCollection {
     const queryParameters = new QueryParameters(queryParams);
     return new SimulationCollection(this.client, SimulationPaths.list + queryParameters.toQueryString());
   }
 
-  public async create<T extends IEventName | SimulationScenarioType>(
+  public async create<T extends SimulationEventType>(
     createSimulationParameters: CreateSimulationRequestBody<T>,
   ): Promise<Simulation<T>> {
     const response = await this.client.post<
@@ -44,7 +43,7 @@ export class SimulationsResource extends BaseResource {
     return new Simulation(data);
   }
 
-  public async get<T extends IEventName | SimulationScenarioType>(simulationId: string): Promise<Simulation<T>> {
+  public async get<T extends SimulationEventType>(simulationId: string): Promise<Simulation<T>> {
     const urlWithPathParams = new PathParameters(SimulationPaths.get, {
       simulation_id: simulationId,
     }).deriveUrl();
@@ -58,7 +57,7 @@ export class SimulationsResource extends BaseResource {
     return new Simulation(data);
   }
 
-  public async update<T extends IEventName | SimulationScenarioType>(
+  public async update<T extends SimulationEventType | undefined = undefined>(
     simulationId: string,
     updateSimulation: UpdateSimulationRequestBody<T>,
   ): Promise<Simulation<T>> {

--- a/src/resources/simulations/operations/create-simulation-request-body.ts
+++ b/src/resources/simulations/operations/create-simulation-request-body.ts
@@ -5,11 +5,11 @@
  */
 
 import type { SimulationScenarioType } from '../../../enums';
-import type { IEventName } from '../../../notifications';
+import type { EventMap, IEventName } from '../../../notifications';
 
-export interface CreateSimulationRequestBody {
+export interface CreateSimulationRequestBody<T extends IEventName | SimulationScenarioType> {
   notificationSettingId: string;
-  type: IEventName | SimulationScenarioType;
+  type: T;
   name: string;
-  payload?: any;
+  payload?: (T extends IEventName ? EventMap[T] : null) | null;
 }

--- a/src/resources/simulations/operations/create-simulation-request-body.ts
+++ b/src/resources/simulations/operations/create-simulation-request-body.ts
@@ -4,10 +4,10 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-import type { SimulationScenarioType } from '../../../enums';
+import type { SimulationEventType } from '../../../enums';
 import type { EventMap, IEventName } from '../../../notifications';
 
-export interface CreateSimulationRequestBody<T extends IEventName | SimulationScenarioType> {
+export interface CreateSimulationRequestBody<T extends SimulationEventType> {
   notificationSettingId: string;
   type: T;
   name: string;

--- a/src/resources/simulations/operations/update-simulation-request-body.ts
+++ b/src/resources/simulations/operations/update-simulation-request-body.ts
@@ -4,10 +4,10 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-import type { SimulationScenarioType, Status } from '../../../enums';
+import type { SimulationEventType, Status } from '../../../enums';
 import type { EventMap, IEventName } from '../../../notifications';
 
-export interface UpdateSimulationRequestBody<T extends IEventName | SimulationScenarioType> {
+export interface UpdateSimulationRequestBody<T extends SimulationEventType | undefined = undefined> {
   notificationSettingId?: string;
   name?: string;
   status?: Status;

--- a/src/resources/simulations/operations/update-simulation-request-body.ts
+++ b/src/resources/simulations/operations/update-simulation-request-body.ts
@@ -5,12 +5,12 @@
  */
 
 import type { SimulationScenarioType, Status } from '../../../enums';
-import type { IEventName } from '../../../notifications';
+import type { EventMap, IEventName } from '../../../notifications';
 
-export interface UpdateSimulationRequestBody {
+export interface UpdateSimulationRequestBody<T extends IEventName | SimulationScenarioType> {
   notificationSettingId?: string;
   name?: string;
   status?: Status;
-  type?: IEventName | SimulationScenarioType;
-  payload?: any;
+  type?: T;
+  payload?: (T extends IEventName ? EventMap[T] : null) | null;
 }

--- a/src/types/simulation-run-event/simulation-run-event-response.ts
+++ b/src/types/simulation-run-event/simulation-run-event-response.ts
@@ -4,14 +4,13 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
+import type { SimulationRunEventStatus, SimulationEventType } from '../../enums';
 import type { ISimulationEventRequest, ISimulationEventResponse } from '../shared';
-import type { SimulationRunEventStatus, SimulationScenarioType } from '../../enums';
-import type { IEventName } from '../../notifications';
 
 export interface ISimulationRunEventResponse {
   id: string;
   status: SimulationRunEventStatus;
-  event_type: IEventName | SimulationScenarioType;
+  event_type: SimulationEventType;
   payload: any;
   request?: ISimulationEventRequest | null;
   response?: ISimulationEventResponse | null;

--- a/src/types/simulation-run/simulation-run-response.ts
+++ b/src/types/simulation-run/simulation-run-response.ts
@@ -5,14 +5,13 @@
  */
 
 import type { ISimulationRunEventResponse } from '..';
-import type { SimulationRunStatus, SimulationScenarioType } from '../../enums';
-import type { IEventName } from '../../notifications';
+import type { SimulationRunStatus, SimulationEventType } from '../../enums';
 
 export interface ISimulationRunResponse {
   id: string;
   status: SimulationRunStatus;
   created_at: string;
   updated_at: string;
-  type: IEventName | SimulationScenarioType;
+  type: SimulationEventType;
   events?: ISimulationRunEventResponse[];
 }

--- a/src/types/simulation/simulation-response.ts
+++ b/src/types/simulation/simulation-response.ts
@@ -5,15 +5,15 @@
  */
 
 import type { SimulationScenarioType, Status } from '../../enums';
-import type { IEventName } from '../../notifications';
+import type { IEventName, EventMap } from '../../notifications';
 
-export interface ISimulationResponse {
+export interface ISimulationResponse<T extends IEventName | SimulationScenarioType> {
   id: string;
   status: Status;
   notification_setting_id: string;
   name: string;
-  type: IEventName | SimulationScenarioType;
-  payload?: any;
+  type: T;
+  payload?: (T extends IEventName ? EventMap[T] : null) | null;
   last_run_at?: string | null;
   created_at: string;
   updated_at: string;

--- a/src/types/simulation/simulation-response.ts
+++ b/src/types/simulation/simulation-response.ts
@@ -4,10 +4,10 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-import type { SimulationScenarioType, Status } from '../../enums';
+import type { SimulationEventType, Status } from '../../enums';
 import type { IEventName, EventMap } from '../../notifications';
 
-export interface ISimulationResponse<T extends IEventName | SimulationScenarioType> {
+export interface ISimulationResponse<T extends SimulationEventType | undefined = undefined> {
   id: string;
   status: Status;
   notification_setting_id: string;


### PR DESCRIPTION
Updates the `Simulation` type to be generic allowing us to narrow down the type of the `payload` based on the event `type`, this will give intellisense on the payload when creating or updating simulations

<img width="475" alt="image" src="https://github.com/user-attachments/assets/25bdd4f0-82c6-4be8-88d7-f9a2d297fa74">

<img width="496" alt="image" src="https://github.com/user-attachments/assets/91e79b4d-ff5c-4779-8e6f-3dff9a9e8f1f">

or if you know the event type for the simulation you are retrieving, you can manually type it
```
const sim = await paddle.simulations.get<'subscription.created'>("ntfsim_01j990fgdbjyfqw28f19kvcgf2");
```
to get the typing on the payload.

Lists are maybe a little harder to try and narrow down so these are left alone but could be coerced by the user with something like
```
import type { SubscriptionNotification } from '@paddle/paddle-node-sdk'

const collection = paddle.simulations.list();
const list = await collection.next();
const payload = list[0].payload as SubscriptionNotification;
```