### PR TITLE
feat(NotificationSetting): Add trafficSource field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ When we make [non-breaking changes](https://developer.paddle.com/api-reference/a
 
 This means when upgrading minor versions of the SDK, you may notice type errors. You can safely ignore these or fix by adding additional type guards.
 
+## 1.9.0 - 2024-10-15
+
+### Added
+
+- Added the `trafficSource` filter on notification settings
+
 ## 1.8.0 - 2024-10-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-node-sdk",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "A Node.js SDK that you can use to integrate Paddle Billing with applications written in server-side JavaScript.",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/__tests__/mocks/resources/notification-settings.mock.ts
+++ b/src/__tests__/mocks/resources/notification-settings.mock.ts
@@ -22,6 +22,7 @@ export const UpdateNotificationSettingsMock: UpdateNotificationSettingsRequestBo
   apiVersion: 10,
   includeSensitiveFields: true,
   subscribedEvents: ['address.updated'],
+  trafficSource: 'platform',
 };
 
 export const CreateNotificationSettingsExpectation = {
@@ -38,6 +39,7 @@ export const UpdateNotificationSettingsExpectation = {
   api_version: 10,
   include_sensitive_fields: true,
   subscribed_events: ['address.updated'],
+  traffic_source: 'platform',
 };
 
 export const NotificationSettingsMock: INotificationSettingsResponse = {

--- a/src/entities/notification-settings/notification-settings.ts
+++ b/src/entities/notification-settings/notification-settings.ts
@@ -3,7 +3,7 @@
  *  Do not make changes to this file.
  *  Changes may be overwritten as part of auto-generation.
  */
-import { type NotificationSettingsType } from '../../enums';
+import { type TrafficSource, type NotificationSettingsType } from '../../enums';
 import { EventType } from '../event-types';
 import { type INotificationSettingsResponse } from '../../types/notification-settings';
 
@@ -15,6 +15,7 @@ export class NotificationSettings {
   public readonly active: boolean;
   public readonly apiVersion: number;
   public readonly includeSensitiveFields: boolean;
+  public readonly trafficSource: TrafficSource;
   public readonly subscribedEvents: EventType[];
   public readonly endpointSecretKey: string;
 
@@ -26,6 +27,7 @@ export class NotificationSettings {
     this.active = notificationSettings.active;
     this.apiVersion = notificationSettings.api_version;
     this.includeSensitiveFields = notificationSettings.include_sensitive_fields;
+    this.trafficSource = notificationSettings.traffic_source;
     this.subscribedEvents = notificationSettings.subscribed_events.map(
       (subscribed_event) => new EventType(subscribed_event),
     );

--- a/src/enums/notification-settings/traffic-source.ts
+++ b/src/enums/notification-settings/traffic-source.ts
@@ -4,5 +4,4 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-export * from './notification-settings-type';
-export * from './traffic-source';
+export type TrafficSource = 'platform' | 'simulation' | 'all';

--- a/src/resources/notification-settings/operations/create-notification-settings-request-body.ts
+++ b/src/resources/notification-settings/operations/create-notification-settings-request-body.ts
@@ -3,7 +3,7 @@
  *  Do not make changes to this file.
  *  Changes may be overwritten as part of auto-generation.
  */
-import { type NotificationSettingsType } from '../../../enums';
+import { type TrafficSource, type NotificationSettingsType } from '../../../enums';
 import { type IEventName } from '../../../notifications';
 
 export interface CreateNotificationSettingsRequestBody {
@@ -13,4 +13,5 @@ export interface CreateNotificationSettingsRequestBody {
   type: NotificationSettingsType;
   apiVersion?: number | null;
   includeSensitiveFields?: boolean | null;
+  trafficSource?: TrafficSource | null;
 }

--- a/src/resources/notification-settings/operations/list-notification-settings-query-parameters.ts
+++ b/src/resources/notification-settings/operations/list-notification-settings-query-parameters.ts
@@ -4,9 +4,12 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
+import { type TrafficSource } from '../../../enums';
+
 export interface ListNotificationSettingsQueryParameters {
   after?: string;
   perPage?: number;
   orderBy?: string;
   active?: boolean;
+  trafficSource?: TrafficSource;
 }

--- a/src/resources/notification-settings/operations/update-notification-settings-request-body.ts
+++ b/src/resources/notification-settings/operations/update-notification-settings-request-body.ts
@@ -3,6 +3,7 @@
  *  Do not make changes to this file.
  *  Changes may be overwritten as part of auto-generation.
  */
+import { type TrafficSource } from '../../../enums';
 import { type IEventName } from '../../../notifications';
 
 export interface UpdateNotificationSettingsRequestBody {
@@ -12,4 +13,5 @@ export interface UpdateNotificationSettingsRequestBody {
   apiVersion?: number;
   includeSensitiveFields?: boolean;
   subscribedEvents?: IEventName[];
+  trafficSource?: TrafficSource;
 }

--- a/src/types/notification-settings/notification-settings-response.ts
+++ b/src/types/notification-settings/notification-settings-response.ts
@@ -3,7 +3,7 @@
  *  Do not make changes to this file.
  *  Changes may be overwritten as part of auto-generation.
  */
-import { type NotificationSettingsType } from '../../enums';
+import { type TrafficSource, type NotificationSettingsType } from '../../enums';
 import { type IEventTypeResponse } from '../event-types';
 
 export interface INotificationSettingsResponse {
@@ -14,6 +14,7 @@ export interface INotificationSettingsResponse {
   active: boolean;
   api_version: number;
   include_sensitive_fields: boolean;
+  traffic_source: TrafficSource;
   subscribed_events: IEventTypeResponse[];
   endpoint_secret_key: string;
 }


### PR DESCRIPTION
Adds the `trafficSource` types to notification settings for create, update and list

Usage:

```
  const ntfSet = await paddle.notificationSettings.create({
    description: "Test Notification Setting",
    destination: "https://your.app/webhook",
    subscribedEvents: ["address.created"],
    type: "url",
    trafficSource: "simulation",
  });
```