### PR TITLE
fix(SubscriptionNotification): mark transactionId as non-null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,21 @@ When we make [non-breaking changes](https://developer.paddle.com/api-reference/a
 
 This means when upgrading minor versions of the SDK, you may notice type errors. You can safely ignore these or fix by adding additional type guards.
 
+## 1.9.1 - 2024-10-16
+
+### Fixed
+
+- Updated `transactionId` in `SubscriptionNotification` to be a non-nullable field.
+
+---
+
 ## 1.9.0 - 2024-10-15
 
 ### Added
 
 - Added the `trafficSource` filter on notification settings
+
+---
 
 ## 1.8.0 - 2024-10-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This means when upgrading minor versions of the SDK, you may notice type errors.
 
 ### Fixed
 
-- Updated `transactionId` in `SubscriptionNotification` to be a non-nullable field.
+- Omitted the `transactionId` completely from `SubscriptionNotification` and created a separate `SubscriptionCreatedNotification` with the non-null `transactionId`
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-node-sdk",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "A Node.js SDK that you can use to integrate Paddle Billing with applications written in server-side JavaScript.",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/__tests__/mocks/notifications/subscription-activated.mock.ts
+++ b/src/__tests__/mocks/notifications/subscription-activated.mock.ts
@@ -223,7 +223,6 @@ export const SubscriptionActivatedMockExpectation = {
     scheduledChange: null,
     startedAt: '2023-08-11T08:07:35.449123Z',
     status: 'active',
-    transactionId: 'txn_01h8bxpvx398a7zbawb77y0kp5',
     updatedAt: '2023-08-11T08:07:36.892822Z',
   },
   eventId: 'evt_01h7ht60mmw6d4sf4h38g3t4yq',

--- a/src/__tests__/mocks/notifications/subscription-canceled.mock.ts
+++ b/src/__tests__/mocks/notifications/subscription-canceled.mock.ts
@@ -296,7 +296,6 @@ export const SubscriptionCanceledMockExpectation = {
     scheduledChange: null,
     startedAt: '2023-08-11T08:07:35.449123Z',
     status: 'canceled',
-    transactionId: 'txn_01h8bxpvx398a7zbawb77y0kp5',
     updatedAt: '2024-01-11T08:34:01.798065409Z',
   },
   eventId: 'evt_01h7jk37p1ezj1k5b4kt83t35j',

--- a/src/__tests__/mocks/notifications/subscription-imported.mock.ts
+++ b/src/__tests__/mocks/notifications/subscription-imported.mock.ts
@@ -293,7 +293,6 @@ export const SubscriptionImportedMockExpectation = {
     scheduledChange: null,
     startedAt: '2023-04-13T09:07:04.730931Z',
     status: 'active',
-    transactionId: 'txn_01h8bxpvx398a7zbawb77y0kp5',
     updatedAt: '2023-04-13T09:07:06.628577Z',
   },
   eventId: 'evt_01gxwxwnghn8xa7amfwqb0992q',

--- a/src/__tests__/mocks/notifications/subscription-past-due.mock.ts
+++ b/src/__tests__/mocks/notifications/subscription-past-due.mock.ts
@@ -223,7 +223,6 @@ export const SubscriptionPastDueMockExpectation = {
     scheduledChange: null,
     startedAt: '2023-08-11T08:07:35.449123Z',
     status: 'past_due',
-    transactionId: 'txn_01h8bxpvx398a7zbawb77y0kp5',
     updatedAt: '2023-10-11T08:08:04.929417Z',
   },
   eventId: 'evt_01h7jagte1wnq80w5bw5gbmrwk',

--- a/src/__tests__/mocks/notifications/subscription-paused.mock.ts
+++ b/src/__tests__/mocks/notifications/subscription-paused.mock.ts
@@ -220,7 +220,6 @@ export const SubscriptionPausedMockExpectation = {
     scheduledChange: null,
     startedAt: '2023-08-11T08:07:35.449123Z',
     status: 'paused',
-    transactionId: 'txn_01h8bxpvx398a7zbawb77y0kp5',
     updatedAt: '2023-11-11T08:08:19.863737035Z',
   },
   eventId: 'evt_01h7jcst3syp03dk5f0m8h204f',

--- a/src/__tests__/mocks/notifications/subscription-resumed.mock.ts
+++ b/src/__tests__/mocks/notifications/subscription-resumed.mock.ts
@@ -223,7 +223,6 @@ export const SubscriptionResumedMockExpectation = {
     scheduledChange: null,
     startedAt: '2023-08-11T08:07:35.449123Z',
     status: 'active',
-    transactionId: 'txn_01h8bxpvx398a7zbawb77y0kp5',
     updatedAt: '2023-11-11T08:33:04.453253Z',
   },
   eventId: 'evt_01h7je74dkvjc4b2pt8sgsfm7f',

--- a/src/__tests__/mocks/notifications/subscription-trialing.mock.ts
+++ b/src/__tests__/mocks/notifications/subscription-trialing.mock.ts
@@ -129,7 +129,6 @@ export const SubscriptionTrialingMockExpectation = {
     startedAt: '2023-08-18T13:15:46.864158Z',
     status: 'trialing',
     updatedAt: '2023-08-18T13:15:46.864163Z',
-    transactionId: 'txn_01h8bxpvx398a7zbawb77y0kp5',
   },
   eventId: 'evt_01h84cka4p40e737vm1ajb2bc5',
   eventType: 'subscription.trialing',

--- a/src/__tests__/mocks/notifications/subscription-updated.mock.ts
+++ b/src/__tests__/mocks/notifications/subscription-updated.mock.ts
@@ -223,7 +223,6 @@ export const SubscriptionUpdatedMockExpectation = {
     scheduledChange: null,
     startedAt: '2023-08-11T08:07:35.449123Z',
     status: 'active',
-    transactionId: 'txn_01h8bxpvx398a7zbawb77y0kp5',
     updatedAt: '2023-09-11T08:07:47.341611Z',
   },
   eventId: 'evt_01h7j296f40h99m4dcrr6h4as8',

--- a/src/notifications/entities/subscription/index.ts
+++ b/src/notifications/entities/subscription/index.ts
@@ -4,6 +4,7 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
+export * from './subscription-created-notification';
 export * from './subscription-discount-notification';
 export * from './subscription-time-period-notification';
 export * from './subscription-scheduled-change-notification';

--- a/src/notifications/entities/subscription/subscription-created-notification.ts
+++ b/src/notifications/entities/subscription/subscription-created-notification.ts
@@ -14,12 +14,13 @@ import {
   TimePeriodNotification,
 } from '../index';
 import { type CollectionMode, type CurrencyCode, type SubscriptionStatus } from '../../../enums';
-import { type ISubscriptionNotificationResponse } from '../../types';
+import { type ISubscriptionCreatedNotificationResponse } from '../../types';
 import { type CustomData } from '../../../entities';
 
-export class SubscriptionNotification {
+export class SubscriptionCreatedNotification {
   public readonly id: string;
   public readonly status: SubscriptionStatus;
+  public readonly transactionId: string;
   public readonly customerId: string;
   public readonly addressId: string;
   public readonly businessId: string | null;
@@ -41,9 +42,10 @@ export class SubscriptionNotification {
   public readonly customData: CustomData | null;
   public readonly importMeta: ImportMetaNotification | null;
 
-  constructor(subscription: ISubscriptionNotificationResponse) {
+  constructor(subscription: ISubscriptionCreatedNotificationResponse) {
     this.id = subscription.id;
     this.status = subscription.status;
+    this.transactionId = subscription.transaction_id;
     this.customerId = subscription.customer_id;
     this.addressId = subscription.address_id;
     this.businessId = subscription.business_id ? subscription.business_id : null;

--- a/src/notifications/entities/subscription/subscription-notification.ts
+++ b/src/notifications/entities/subscription/subscription-notification.ts
@@ -20,7 +20,7 @@ import { type CustomData } from '../../../entities';
 export class SubscriptionNotification {
   public readonly id: string;
   public readonly status: SubscriptionStatus;
-  public readonly transactionId: string | null;
+  public readonly transactionId: string;
   public readonly customerId: string;
   public readonly addressId: string;
   public readonly businessId: string | null;
@@ -45,7 +45,7 @@ export class SubscriptionNotification {
   constructor(subscription: ISubscriptionNotificationResponse) {
     this.id = subscription.id;
     this.status = subscription.status;
-    this.transactionId = subscription.transaction_id ? subscription.transaction_id : null;
+    this.transactionId = subscription.transaction_id;
     this.customerId = subscription.customer_id;
     this.addressId = subscription.address_id;
     this.businessId = subscription.business_id ? subscription.business_id : null;

--- a/src/notifications/events/subscription/subscription-activated-event.ts
+++ b/src/notifications/events/subscription/subscription-activated-event.ts
@@ -12,7 +12,7 @@ import { type ISubscriptionNotificationResponse } from '../../types';
 
 export class SubscriptionActivatedEvent extends Event {
   public override readonly eventType = EventName.SubscriptionActivated;
-  public override readonly data: Omit<SubscriptionNotification, 'transactionId'>;
+  public override readonly data: SubscriptionNotification;
 
   constructor(response: IEventsResponse<ISubscriptionNotificationResponse>) {
     super(response);

--- a/src/notifications/events/subscription/subscription-canceled-event.ts
+++ b/src/notifications/events/subscription/subscription-canceled-event.ts
@@ -12,7 +12,7 @@ import { type ISubscriptionNotificationResponse } from '../../types';
 
 export class SubscriptionCanceledEvent extends Event {
   public override readonly eventType = EventName.SubscriptionCanceled;
-  public override readonly data: Omit<SubscriptionNotification, 'transactionId'>;
+  public override readonly data: SubscriptionNotification;
 
   constructor(response: IEventsResponse<ISubscriptionNotificationResponse>) {
     super(response);

--- a/src/notifications/events/subscription/subscription-created-event.ts
+++ b/src/notifications/events/subscription/subscription-created-event.ts
@@ -5,17 +5,17 @@
  */
 
 import { Event } from '../../../entities/events/event';
-import { SubscriptionNotification } from '../../entities';
+import { SubscriptionCreatedNotification } from '../../entities';
 import { EventName } from '../../helpers';
 import { type IEventsResponse } from '../../../types';
-import { type ISubscriptionNotificationResponse } from '../../types';
+import { type ISubscriptionCreatedNotificationResponse } from '../../types';
 
 export class SubscriptionCreatedEvent extends Event {
   public override readonly eventType = EventName.SubscriptionCreated;
-  public override readonly data: SubscriptionNotification;
+  public override readonly data: SubscriptionCreatedNotification;
 
-  constructor(response: IEventsResponse<ISubscriptionNotificationResponse>) {
+  constructor(response: IEventsResponse<ISubscriptionCreatedNotificationResponse>) {
     super(response);
-    this.data = new SubscriptionNotification(response.data);
+    this.data = new SubscriptionCreatedNotification(response.data);
   }
 }

--- a/src/notifications/events/subscription/subscription-imported-event.ts
+++ b/src/notifications/events/subscription/subscription-imported-event.ts
@@ -12,7 +12,7 @@ import { type ISubscriptionNotificationResponse } from '../../types';
 
 export class SubscriptionImportedEvent extends Event {
   public override readonly eventType = EventName.SubscriptionImported;
-  public override readonly data: Omit<SubscriptionNotification, 'transactionId'>;
+  public override readonly data: SubscriptionNotification;
 
   constructor(response: IEventsResponse<ISubscriptionNotificationResponse>) {
     super(response);

--- a/src/notifications/events/subscription/subscription-past-due-event.ts
+++ b/src/notifications/events/subscription/subscription-past-due-event.ts
@@ -12,7 +12,7 @@ import { type ISubscriptionNotificationResponse } from '../../types';
 
 export class SubscriptionPastDueEvent extends Event {
   public override readonly eventType = EventName.SubscriptionPastDue;
-  public override readonly data: Omit<SubscriptionNotification, 'transactionId'>;
+  public override readonly data: SubscriptionNotification;
 
   constructor(response: IEventsResponse<ISubscriptionNotificationResponse>) {
     super(response);

--- a/src/notifications/events/subscription/subscription-paused-event.ts
+++ b/src/notifications/events/subscription/subscription-paused-event.ts
@@ -12,7 +12,7 @@ import { type ISubscriptionNotificationResponse } from '../../types';
 
 export class SubscriptionPausedEvent extends Event {
   public override readonly eventType = EventName.SubscriptionPaused;
-  public override readonly data: Omit<SubscriptionNotification, 'transactionId'>;
+  public override readonly data: SubscriptionNotification;
 
   constructor(response: IEventsResponse<ISubscriptionNotificationResponse>) {
     super(response);

--- a/src/notifications/events/subscription/subscription-resumed-event.ts
+++ b/src/notifications/events/subscription/subscription-resumed-event.ts
@@ -12,7 +12,7 @@ import { type ISubscriptionNotificationResponse } from '../../types';
 
 export class SubscriptionResumedEvent extends Event {
   public override readonly eventType = EventName.SubscriptionResumed;
-  public override readonly data: Omit<SubscriptionNotification, 'transactionId'>;
+  public override readonly data: SubscriptionNotification;
 
   constructor(response: IEventsResponse<ISubscriptionNotificationResponse>) {
     super(response);

--- a/src/notifications/events/subscription/subscription-trialing-event.ts
+++ b/src/notifications/events/subscription/subscription-trialing-event.ts
@@ -12,7 +12,7 @@ import { type ISubscriptionNotificationResponse } from '../../types';
 
 export class SubscriptionTrialingEvent extends Event {
   public override readonly eventType = EventName.SubscriptionTrialing;
-  public override readonly data: Omit<SubscriptionNotification, 'transactionId'>;
+  public override readonly data: SubscriptionNotification;
 
   constructor(response: IEventsResponse<ISubscriptionNotificationResponse>) {
     super(response);

--- a/src/notifications/events/subscription/subscription-updated-event.ts
+++ b/src/notifications/events/subscription/subscription-updated-event.ts
@@ -12,7 +12,7 @@ import { type ISubscriptionNotificationResponse } from '../../types';
 
 export class SubscriptionUpdatedEvent extends Event {
   public override readonly eventType = EventName.SubscriptionUpdated;
-  public override readonly data: Omit<SubscriptionNotification, 'transactionId'>;
+  public override readonly data: SubscriptionNotification;
 
   constructor(response: IEventsResponse<ISubscriptionNotificationResponse>) {
     super(response);

--- a/src/notifications/types/subscription/index.ts
+++ b/src/notifications/types/subscription/index.ts
@@ -4,6 +4,7 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
+export * from './subscription-created-notification-response';
 export * from './subscription-discount-notification-response';
 export * from './subscription-time-period-notification-response';
 export * from './subscription-scheduled-change-notification-response';

--- a/src/notifications/types/subscription/subscription-created-notification-response.ts
+++ b/src/notifications/types/subscription/subscription-created-notification-response.ts
@@ -16,9 +16,10 @@ import {
 import { type CollectionMode, type CurrencyCode, type SubscriptionStatus } from '../../../enums';
 import { type ICustomData } from '../../../types';
 
-export interface ISubscriptionNotificationResponse {
+export interface ISubscriptionCreatedNotificationResponse {
   id: string;
   status: SubscriptionStatus;
+  transaction_id: string;
   customer_id: string;
   address_id: string;
   business_id?: string | null;

--- a/src/types/events/events-response.ts
+++ b/src/types/events/events-response.ts
@@ -15,6 +15,7 @@ import {
   type IPriceNotificationResponse,
   type IProductNotificationResponse,
   type IReportNotificationResponse,
+  type ISubscriptionCreatedNotificationResponse,
   type ISubscriptionNotificationResponse,
   type ITransactionNotificationResponse,
 } from '../../notifications';
@@ -123,7 +124,7 @@ interface ISubscriptionCanceled extends IEventsResponse<ISubscriptionNotificatio
   event_type: EventName.SubscriptionCanceled;
 }
 
-interface ISubscriptionCreated extends IEventsResponse<ISubscriptionNotificationResponse> {
+interface ISubscriptionCreated extends IEventsResponse<ISubscriptionCreatedNotificationResponse> {
   event_type: EventName.SubscriptionCreated;
 }
 


### PR DESCRIPTION
Updates the `transactionId` for `SubscriptionNotification` to be non-nullable, the field is still omitted from all notifications other than subscription created