### PR TITLE
chore: bump version to v2 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,33 +12,21 @@ When we make [non-breaking changes](https://developer.paddle.com/api-reference/a
 
 This means when upgrading minor versions of the SDK, you may notice type errors. You can safely ignore these or fix by adding additional type guards.
 
-## 2.0.0-rc.2 - 2024-11-19
-
-### Added
-
-- Added the `trafficSource` filter on notification settings
-- Omitted the `transactionId` completely from `SubscriptionNotification` and created a separate `SubscriptionCreatedNotification` with the non-null `transactionId`
-- Added `paymentMethods` resources
-- Added `generateAuthToken` for customer
-
-## 2.0.0-rc.1 - 2024-10-08
-
-### Added
-
-- Added `simulationTypes` resources
-- Added `simulations` resources
-- Added `simulationRuns` resources
-- Added `simulationRunEvents` resources
-
----
-
-## 2.0.0-rc.0 - 2024-09-26
+## 2.0.0 - 2024-11-20
 
 > **Breaking changes:** This version includes major improvements that introduce breaking changes. These are called out below.
 
 ### Added
 
 - Added support for edge runtime.
+- Added `simulationTypes` resources
+- Added `simulations` resources
+- Added `simulationRuns` resources
+- Added `simulationRunEvents` resources
+- Added the `trafficSource` filter on notification settings
+- Omitted the `transactionId` completely from `SubscriptionNotification` and created a separate `SubscriptionCreatedNotification` with the non-null `transactionId`
+- Added `paymentMethods` resources
+- Added `generateAuthToken` for customer
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-node-sdk",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0",
   "description": "A Node.js SDK that you can use to integrate Paddle Billing with applications written in server-side JavaScript.",
   "main": "dist/cjs/index.cjs.node.js",
   "module": "dist/esm/index.esm.node.js",


### PR DESCRIPTION
Release v2 as a stable release

## Related updates:

- https://github.com/PaddleHQ/paddle-node-sdk/pull/45
- https://github.com/PaddleHQ/paddle-node-sdk/pull/69