### PR TITLE
fix: update customer portal sessions imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ When we make [non-breaking changes](https://developer.paddle.com/api-reference/a
 
 This means when upgrading minor versions of the SDK, you may notice type errors. You can safely ignore these or fix by adding additional type guards.
 
+## 2.1.1 - 2024-11-25
+
+### Fixed
+
+- Updated imports to use `.js` extension
+
 ## 2.1.0 - 2024-11-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-node-sdk",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A Node.js SDK that you can use to integrate Paddle Billing with applications written in server-side JavaScript.",
   "main": "dist/cjs/index.cjs.node.js",
   "module": "dist/esm/index.esm.node.js",

--- a/src/resources/customer-portal-sessions/index.ts
+++ b/src/resources/customer-portal-sessions/index.ts
@@ -6,8 +6,8 @@
 
 import { CustomerPortalSession } from '../../entities/index.js';
 import { type ICustomerPortalSessionResponse } from '../../types/index.js';
-import { type ErrorResponse, type Response } from '../../internal';
-import { BaseResource, PathParameters } from '../../internal/base';
+import { type ErrorResponse, type Response } from '../../internal/index.js';
+import { BaseResource, PathParameters } from '../../internal/base/index.js';
 import { type CreateCustomerPortalSessionRequestBody } from './operations/index.js';
 
 const CustomerPortalSessionPaths = {


### PR DESCRIPTION
Related to issue: https://github.com/PaddleHQ/paddle-node-sdk/issues/76

With the 2.0.0 release to support the additional runtimes, the `.js` extension needs to be added to all imports