### PR TITLE
chore: add eslint file extension rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,3 +1,5 @@
+plugins:
+  - import
 env:
   browser: true
   es2021: true
@@ -19,6 +21,10 @@ rules:
   'generator-star-spacing': 'off'
   '@typescript-eslint/naming-convention': 'off'
   '@typescript-eslint/no-extraneous-class': 'off'
+  'import/extensions':
+    - error
+    - always
+    - js: always
 ignorePatterns:
   - 'jest.config.js'
   - '**/__tests__/**'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ When we make [non-breaking changes](https://developer.paddle.com/api-reference/a
 
 This means when upgrading minor versions of the SDK, you may notice type errors. You can safely ignore these or fix by adding additional type guards.
 
+## 2.1.2 - 2024-11-26
+
+### Fixed
+
+- Updated payment-methods export to use `.js` extension
+
+### Added
+
+- ESLint rule to ensure `.js` extension is provided
+
 ## 2.1.1 - 2024-11-25
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-node-sdk",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A Node.js SDK that you can use to integrate Paddle Billing with applications written in server-side JavaScript.",
   "main": "dist/cjs/index.cjs.node.js",
   "module": "dist/esm/index.esm.node.js",

--- a/src/resources/payment-methods/index.ts
+++ b/src/resources/payment-methods/index.ts
@@ -10,7 +10,7 @@ import { type ErrorResponse, type Response } from '../../internal/index.js';
 import { BaseResource, PathParameters, QueryParameters } from '../../internal/base/index.js';
 import { type ListCustomerPaymentMethodQueryParameters } from './operations/index.js';
 
-export * from './operations';
+export * from './operations/index.js';
 
 const PaymentMethodPaths = {
   list: '/customers/{customer_id}/payment-methods',


### PR DESCRIPTION
Related to the following issue - https://github.com/PaddleHQ/paddle-node-sdk/issues/76

Adds the `eslint-plugin-import` rule to ensure that all imports and exports include the `.js` extension