### PR TITLE
Adjustment type and VND currency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ When we make [non-breaking changes](https://developer.paddle.com/api-reference/a
 
 This means when upgrading minor versions of the SDK, you may notice type errors. You can safely ignore these or fix by adding additional type guards.
 
+## 2.2.0 - 2024-12-12
+
+### Added
+
+- `VND` (Vietnamese dong) as new currency
+- Added `adjustment.type` which is either `partial` which should include `items` or `full` where `items` are not required
+
 ## 2.1.3 - 2024-11-29
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-node-sdk",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "description": "A Node.js SDK that you can use to integrate Paddle Billing with applications written in server-side JavaScript.",
   "main": "dist/cjs/index.cjs.node.js",
   "module": "dist/esm/index.esm.node.js",

--- a/src/__tests__/mocks/notifications/adjustment-created.mock.ts
+++ b/src/__tests__/mocks/notifications/adjustment-created.mock.ts
@@ -24,6 +24,7 @@ export const AdjustmentCreatedMock: IEventsResponse<IAdjustmentResponse> = {
       },
     ],
     action: 'refund',
+    type: 'partial',
     reason: 'error',
     status: 'pending_approval',
     totals: { fee: '5', tax: '8', total: '100', earnings: '87', subtotal: '92', currency_code: 'USD' },
@@ -41,6 +42,7 @@ export const AdjustmentCreatedMock: IEventsResponse<IAdjustmentResponse> = {
 export const AdjustmentCreatedMockExpectation = {
   data: {
     action: 'refund',
+    type: 'partial',
     createdAt: '2023-08-21T14:08:43.297512Z',
     creditAppliedToBalance: true,
     currencyCode: 'USD',

--- a/src/__tests__/mocks/notifications/adjustment-updated.mock.ts
+++ b/src/__tests__/mocks/notifications/adjustment-updated.mock.ts
@@ -24,6 +24,7 @@ export const AdjustmentUpdatedMock: IEventsResponse<IAdjustmentResponse> = {
       },
     ],
     action: 'refund',
+    type: 'partial',
     reason: 'error',
     status: 'approved',
     totals: { fee: '5', tax: '8', total: '100', earnings: '87', subtotal: '92', currency_code: 'USD' },
@@ -41,6 +42,7 @@ export const AdjustmentUpdatedMock: IEventsResponse<IAdjustmentResponse> = {
 export const AdjustmentUpdatedMockExpectation = {
   data: {
     action: 'refund',
+    type: 'partial',
     createdAt: '2023-08-21T14:08:43.297512Z',
     creditAppliedToBalance: true,
     currencyCode: 'USD',

--- a/src/__tests__/mocks/resources/adjustments.mock.ts
+++ b/src/__tests__/mocks/resources/adjustments.mock.ts
@@ -36,6 +36,7 @@ export const CreateAdjustmentExpectation = {
 
 export const AdjustmentMock: IAdjustmentResponse = {
   action: 'credit',
+  type: 'partial',
   items: [
     {
       amount: '1000',

--- a/src/entities/adjustment/adjustment-item.ts
+++ b/src/entities/adjustment/adjustment-item.ts
@@ -4,7 +4,7 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-import { type AdjustmentType } from '../../enums/index.js';
+import { type AdjustmentItemType } from '../../enums/index.js';
 import { AdjustmentProration } from './adjustment-proration.js';
 import { AdjustmentItemTotals } from './adjustment-item-totals.js';
 import { type IAdjustmentItemResponse } from '../../types/index.js';
@@ -12,7 +12,7 @@ import { type IAdjustmentItemResponse } from '../../types/index.js';
 export class AdjustmentItem {
   public readonly id: string;
   public readonly itemId: string;
-  public readonly type: AdjustmentType;
+  public readonly type: AdjustmentItemType;
   public readonly amount: string | null;
   public readonly proration: AdjustmentProration | null;
   public readonly totals: AdjustmentItemTotals | null;

--- a/src/entities/adjustment/adjustment.ts
+++ b/src/entities/adjustment/adjustment.ts
@@ -4,7 +4,12 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-import { type AdjustmentAction, type AdjustmentStatus, type CurrencyCode } from '../../enums/index.js';
+import {
+  type AdjustmentType,
+  type AdjustmentAction,
+  type AdjustmentStatus,
+  type CurrencyCode,
+} from '../../enums/index.js';
 import { AdjustmentItem } from './adjustment-item.js';
 import { PayoutTotalsAdjustment, TotalAdjustments } from '../shared/index.js';
 import { type IAdjustmentResponse } from '../../types/index.js';
@@ -12,6 +17,7 @@ import { type IAdjustmentResponse } from '../../types/index.js';
 export class Adjustment {
   public readonly id: string;
   public readonly action: AdjustmentAction;
+  public readonly type: AdjustmentType;
   public readonly transactionId: string;
   public readonly subscriptionId: string | null;
   public readonly customerId: string;
@@ -28,6 +34,7 @@ export class Adjustment {
   constructor(adjustment: IAdjustmentResponse) {
     this.id = adjustment.id;
     this.action = adjustment.action;
+    this.type = adjustment.type;
     this.transactionId = adjustment.transaction_id;
     this.subscriptionId = adjustment.subscription_id ? adjustment.subscription_id : null;
     this.customerId = adjustment.customer_id;

--- a/src/entities/subscription/next-transaction-adjustment-item.ts
+++ b/src/entities/subscription/next-transaction-adjustment-item.ts
@@ -4,13 +4,13 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-import { type AdjustmentType } from '../../enums/index.js';
+import { type AdjustmentItemType } from '../../enums/index.js';
 import { AdjustmentItemTotals, AdjustmentProration } from '../adjustment/index.js';
 import { type IAdjustmentItemResponse } from '../../types/index.js';
 
 export class NextTransactionAdjustmentItem {
   public readonly itemId: string;
-  public readonly type: AdjustmentType;
+  public readonly type: AdjustmentItemType;
   public readonly amount: string | null;
   public readonly proration: AdjustmentProration | null;
   public readonly totals: AdjustmentItemTotals | null;

--- a/src/entities/transaction/transaction-adjustment-item.ts
+++ b/src/entities/transaction/transaction-adjustment-item.ts
@@ -4,7 +4,7 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-import { type AdjustmentType } from '../../enums/index.js';
+import { type AdjustmentItemType } from '../../enums/index.js';
 import { TransactionProration } from './transaction-proration.js';
 import { AdjustmentItemTotals } from '../adjustment/index.js';
 import { type ITransactionAdjustmentItemResponse } from '../../types/index.js';
@@ -12,7 +12,7 @@ import { type ITransactionAdjustmentItemResponse } from '../../types/index.js';
 export class TransactionAdjustmentItem {
   public readonly id: string | null;
   public readonly itemId: string;
-  public readonly type: AdjustmentType;
+  public readonly type: AdjustmentItemType;
   public readonly amount: string | null;
   public readonly proration: TransactionProration | null;
   public readonly totals: AdjustmentItemTotals | null;

--- a/src/enums/adjustment/adjustment-item-type.ts
+++ b/src/enums/adjustment/adjustment-item-type.ts
@@ -4,4 +4,4 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-export type AdjustmentType = 'full' | 'partial';
+export type AdjustmentItemType = 'full' | 'partial' | 'tax' | 'proration';

--- a/src/enums/adjustment/index.ts
+++ b/src/enums/adjustment/index.ts
@@ -4,7 +4,8 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-export * from './adjustment-type.js';
-export * from './adjustment-currency-code.js';
 export * from './adjustment-action.js';
+export * from './adjustment-currency-code.js';
+export * from './adjustment-item-type.js';
 export * from './adjustment-status.js';
+export * from './adjustment-type.js';

--- a/src/enums/shared/currency-code.ts
+++ b/src/enums/shared/currency-code.ts
@@ -3,6 +3,7 @@
  *  Do not make changes to this file.
  *  Changes may be overwritten as part of auto-generation.
  */
+
 export type CurrencyCode =
   | 'USD'
   | 'EUR'
@@ -33,4 +34,5 @@ export type CurrencyCode =
   | 'TRY'
   | 'TWD'
   | 'UAH'
+  | 'VND'
   | 'ZAR';

--- a/src/notifications/entities/adjustment/adjustment-item-notification.ts
+++ b/src/notifications/entities/adjustment/adjustment-item-notification.ts
@@ -4,7 +4,7 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-import { type AdjustmentType } from '../../../enums/index.js';
+import { type AdjustmentItemType } from '../../../enums/index.js';
 import { AdjustmentProrationNotification } from './adjustment-proration-notification.js';
 import { AdjustmentItemTotalsNotification } from './adjustment-item-totals-notification.js';
 import { type IAdjustmentItemNotificationResponse } from '../../types/index.js';
@@ -12,7 +12,7 @@ import { type IAdjustmentItemNotificationResponse } from '../../types/index.js';
 export class AdjustmentItemNotification {
   public readonly id: string;
   public readonly itemId: string;
-  public readonly type: AdjustmentType;
+  public readonly type: AdjustmentItemType;
   public readonly amount: string | null;
   public readonly proration: AdjustmentProrationNotification | null;
   public readonly totals: AdjustmentItemTotalsNotification | null;

--- a/src/notifications/entities/adjustment/adjustment-notification.ts
+++ b/src/notifications/entities/adjustment/adjustment-notification.ts
@@ -4,7 +4,12 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-import { type AdjustmentAction, type AdjustmentStatus, type CurrencyCode } from '../../../enums/index.js';
+import {
+  type AdjustmentType,
+  type AdjustmentAction,
+  type AdjustmentStatus,
+  type CurrencyCode,
+} from '../../../enums/index.js';
 import { AdjustmentItemNotification } from './adjustment-item-notification.js';
 import { PayoutTotalsAdjustmentNotification, TotalAdjustmentsNotification } from '../shared/index.js';
 import { type IAdjustmentNotificationResponse } from '../../types/index.js';
@@ -12,6 +17,7 @@ import { type IAdjustmentNotificationResponse } from '../../types/index.js';
 export class AdjustmentNotification {
   public readonly id: string;
   public readonly action: AdjustmentAction;
+  public readonly type: AdjustmentType;
   public readonly transactionId: string;
   public readonly subscriptionId: string | null;
   public readonly customerId: string;
@@ -28,6 +34,7 @@ export class AdjustmentNotification {
   constructor(adjustment: IAdjustmentNotificationResponse) {
     this.id = adjustment.id;
     this.action = adjustment.action;
+    this.type = adjustment.type;
     this.transactionId = adjustment.transaction_id;
     this.subscriptionId = adjustment.subscription_id ? adjustment.subscription_id : null;
     this.customerId = adjustment.customer_id;

--- a/src/notifications/types/adjustment/adjustment-item-notification-response.ts
+++ b/src/notifications/types/adjustment/adjustment-item-notification-response.ts
@@ -5,13 +5,13 @@
  */
 
 import { type IAdjustmentsProrationNotificationResponse } from './adjustments-proration-notification-response.js';
-import { type AdjustmentType } from '../../../enums/index.js';
+import { type AdjustmentItemType } from '../../../enums/index.js';
 import { type IAdjustmentItemTotalsNotificationResponse } from './adjustment-totals-notification-response.js';
 
 export interface IAdjustmentItemNotificationResponse {
   id: string;
   item_id: string;
-  type: AdjustmentType;
+  type: AdjustmentItemType;
   amount?: string | null;
   proration?: IAdjustmentsProrationNotificationResponse | null;
   totals?: IAdjustmentItemTotalsNotificationResponse | null;

--- a/src/notifications/types/adjustment/adjustment-notification-response.ts
+++ b/src/notifications/types/adjustment/adjustment-notification-response.ts
@@ -4,7 +4,12 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-import { type AdjustmentAction, type AdjustmentStatus, type CurrencyCode } from '../../../enums/index.js';
+import {
+  type AdjustmentType,
+  type AdjustmentAction,
+  type AdjustmentStatus,
+  type CurrencyCode,
+} from '../../../enums/index.js';
 import { type IAdjustmentItemNotificationResponse } from './adjustment-item-notification-response.js';
 import {
   type IPayoutTotalsAdjustmentNotificationResponse,
@@ -14,6 +19,7 @@ import {
 export interface IAdjustmentNotificationResponse {
   id: string;
   action: AdjustmentAction;
+  type: AdjustmentType;
   transaction_id: string;
   subscription_id?: string | null;
   customer_id: string;

--- a/src/resources/adjustments/operations/create-adjustment-request-body.ts
+++ b/src/resources/adjustments/operations/create-adjustment-request-body.ts
@@ -4,17 +4,27 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-import { type AdjustmentAction, type AdjustmentType } from '../../../enums/index.js';
+import { type AdjustmentAction, type AdjustmentItemType } from '../../../enums/index.js';
 
 export interface CreateAdjustmentLineItem {
   amount: string | null;
   itemId: string;
-  type: AdjustmentType;
+  type: AdjustmentItemType;
 }
 
-export interface CreateAdjustmentRequestBody {
+interface CreatePartialAdjustmentRequestBody {
   action: AdjustmentAction;
   items: CreateAdjustmentLineItem[];
   reason: string;
   transactionId: string;
+  type?: 'partial';
 }
+
+interface CreateFullAdjustmentRequestBody {
+  action: AdjustmentAction;
+  reason: string;
+  transactionId: string;
+  type?: 'full';
+}
+
+export type CreateAdjustmentRequestBody = CreatePartialAdjustmentRequestBody | CreateFullAdjustmentRequestBody;

--- a/src/types/adjustment/adjustment-item-response.ts
+++ b/src/types/adjustment/adjustment-item-response.ts
@@ -4,14 +4,14 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-import { type AdjustmentType } from '../../enums/index.js';
+import { type AdjustmentItemType } from '../../enums/index.js';
 import { type IAdjustmentsProrationResponse } from './adjustments-proration-response.js';
 import { type IAdjustmentItemTotals } from '../shared/index.js';
 
 export interface IAdjustmentItemResponse {
   id: string;
   item_id: string;
-  type: AdjustmentType;
+  type: AdjustmentItemType;
   amount?: string | null;
   proration?: IAdjustmentsProrationResponse | null;
   totals?: IAdjustmentItemTotals | null;

--- a/src/types/adjustment/adjustment-response.ts
+++ b/src/types/adjustment/adjustment-response.ts
@@ -4,13 +4,19 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-import { type AdjustmentAction, type AdjustmentStatus, type CurrencyCode } from '../../enums/index.js';
+import {
+  type AdjustmentType,
+  type AdjustmentAction,
+  type AdjustmentStatus,
+  type CurrencyCode,
+} from '../../enums/index.js';
 import { type IAdjustmentItemResponse } from './adjustment-item-response.js';
 import { type IPayoutTotalsAdjustmentResponse, type ITotalAdjustmentsResponse } from '../shared/index.js';
 
 export interface IAdjustmentResponse {
   id: string;
   action: AdjustmentAction;
+  type: AdjustmentType;
   transaction_id: string;
   subscription_id?: string | null;
   customer_id: string;

--- a/src/types/transaction/transaction-adjustment-item-response.ts
+++ b/src/types/transaction/transaction-adjustment-item-response.ts
@@ -4,14 +4,14 @@
  *  Changes may be overwritten as part of auto-generation.
  */
 
-import { type AdjustmentType } from '../../enums/index.js';
+import { type AdjustmentItemType } from '../../enums/index.js';
 import { type ITransactionProrationResponse } from './transaction-proration-response.js';
 import { type IAdjustmentItemTotals } from '../shared/index.js';
 
 export interface ITransactionAdjustmentItemResponse {
   id?: string | null;
   item_id: string;
-  type: AdjustmentType;
+  type: AdjustmentItemType;
   amount?: string | null;
   proration?: ITransactionProrationResponse | null;
   totals?: IAdjustmentItemTotals | null;


### PR DESCRIPTION
## Changes:

- Adds `VND` as a supported currency value
- Introduces the optional `type` to adjustments which can be `partial` or `full` if this value is not provided it will be treated as `partial` with the use of items but now you can also provide `full` to omit the items

Usage:
```
  const adjustment = await paddle.adjustments.create({
    action: "refund",
    reason: "Customer requested a refund",
    transactionId,
    type: "full",
  });
```