### PR TITLE
Add proration to transaction preview line items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ When we make [non-breaking changes](https://developer.paddle.com/api-reference/a
 
 This means when upgrading minor versions of the SDK, you may notice type errors. You can safely ignore these or fix by adding additional type guards.
 
+## 2.2.1 - 2024-12-16
+
+### Fixed
+
+- Added `proration` to transaction line items
+
 ## 2.2.0 - 2024-12-12
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-node-sdk",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A Node.js SDK that you can use to integrate Paddle Billing with applications written in server-side JavaScript.",
   "main": "dist/cjs/index.cjs.node.js",
   "module": "dist/esm/index.esm.node.js",

--- a/src/__tests__/mocks/resources/transactions.mock.ts
+++ b/src/__tests__/mocks/resources/transactions.mock.ts
@@ -233,6 +233,13 @@ export const TransactionMock: ITransactionResponse = {
           import_meta: { external_id: '9b95b0b8-e10f-441a-862e-1936a6d818ab', imported_from: 'billing_platform' },
           updated_at: '2024-10-12T07:20:50.52Z',
         },
+        proration: {
+          rate: '1',
+          billing_period: {
+            starts_at: '2024-02-08T11:02:03.946454Z',
+            ends_at: '2024-03-08T11:02:03.946454Z',
+          },
+        },
       },
     ],
   },
@@ -398,6 +405,13 @@ export const TransactionPreviewMock: ITransactionPreviewResponse = {
           created_at: '2024-10-12T07:20:50.52Z',
           updated_at: '2024-10-12T07:20:50.52Z',
           import_meta: { external_id: '9b95b0b8-e10f-441a-862e-1936a6d818ab', imported_from: 'billing_platform' },
+        },
+        proration: {
+          rate: '1',
+          billing_period: {
+            starts_at: '2024-02-08T11:02:03.946454Z',
+            ends_at: '2024-03-08T11:02:03.946454Z',
+          },
         },
       },
     ],

--- a/src/entities/subscription/transaction-line-item-preview.ts
+++ b/src/entities/subscription/transaction-line-item-preview.ts
@@ -7,6 +7,7 @@
 import { Totals, UnitTotals } from '../shared/index.js';
 import { Product } from '../product/index.js';
 import { type ITransactionLineItemPreviewResponse } from '../../types/index.js';
+import { Proration } from '../transaction/proration.js';
 
 export class TransactionLineItemPreview {
   public readonly priceId: string;
@@ -15,6 +16,7 @@ export class TransactionLineItemPreview {
   public readonly unitTotals: UnitTotals;
   public readonly totals: Totals;
   public readonly product: Product;
+  public readonly proration: Proration | null;
 
   constructor(transactionLineItemPreview: ITransactionLineItemPreviewResponse) {
     this.priceId = transactionLineItemPreview.price_id;
@@ -23,5 +25,6 @@ export class TransactionLineItemPreview {
     this.unitTotals = new UnitTotals(transactionLineItemPreview.unit_totals);
     this.totals = new Totals(transactionLineItemPreview.totals);
     this.product = new Product(transactionLineItemPreview.product);
+    this.proration = transactionLineItemPreview.proration ? new Proration(transactionLineItemPreview.proration) : null;
   }
 }

--- a/src/types/shared/transaction-line-item-preview-response.ts
+++ b/src/types/shared/transaction-line-item-preview-response.ts
@@ -7,6 +7,7 @@
 import { type IUnitTotals } from './unit-totals.js';
 import { type ITotals } from './totals.js';
 import { type IProductResponse } from '../product/index.js';
+import { type IProrationResponse } from '../index.js';
 
 export interface ITransactionLineItemPreviewResponse {
   price_id: string;
@@ -15,4 +16,5 @@ export interface ITransactionLineItemPreviewResponse {
   unit_totals: IUnitTotals;
   totals: ITotals;
   product: IProductResponse;
+  proration?: IProrationResponse | null;
 }


### PR DESCRIPTION
Related docs: https://developer.paddle.com/api-reference/transactions/preview-transaction

Adds `proration` to `details.lineItems` for transaction previews