### PR TITLE
Subscription discount can now be null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ When we make [non-breaking changes](https://developer.paddle.com/api-reference/a
 
 This means when upgrading minor versions of the SDK, you may notice type errors. You can safely ignore these or fix by adding additional type guards.
 
+## 2.2.2 - 2024-12-16
+
+### Fixed
+
+- `starts_at` for subscription discount can now be `null`
+
 ## 2.2.1 - 2024-12-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This means when upgrading minor versions of the SDK, you may notice type errors.
 
 ### Fixed
 
-- `starts_at` for subscription discount can now be `null`
+- `discount.startsAt` for Subscriptions can now be `null`
 
 ## 2.2.1 - 2024-12-16
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-node-sdk",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "A Node.js SDK that you can use to integrate Paddle Billing with applications written in server-side JavaScript.",
   "main": "dist/cjs/index.cjs.node.js",
   "module": "dist/esm/index.esm.node.js",

--- a/src/__tests__/mocks/resources/subscriptions.mock.ts
+++ b/src/__tests__/mocks/resources/subscriptions.mock.ts
@@ -356,8 +356,8 @@ export const SubscriptionPreviewMock: ISubscriptionPreviewResponse = {
   canceled_at: '2024-10-12T07:20:50.52Z',
   discount: {
     id: 'dsc_01gv5kpg05xp104ek2fmgjwttf',
-    starts_at: '2024-10-12T07:20:50.52Z',
-    ends_at: '2024-10-12T07:20:50.52Z',
+    starts_at: null,
+    ends_at: null,
   },
   collection_mode: 'automatic',
   billing_details: {

--- a/src/entities/subscription/subscription-discount.ts
+++ b/src/entities/subscription/subscription-discount.ts
@@ -8,12 +8,12 @@ import { type ISubscriptionDiscountResponse } from '../../types/index.js';
 
 export class SubscriptionDiscount {
   public readonly id: string;
-  public readonly startsAt: string;
+  public readonly startsAt: string | null;
   public readonly endsAt: string | null;
 
   constructor(subscriptionDiscount: ISubscriptionDiscountResponse) {
     this.id = subscriptionDiscount.id;
-    this.startsAt = subscriptionDiscount.starts_at;
+    this.startsAt = subscriptionDiscount.starts_at ?? null;
     this.endsAt = subscriptionDiscount.ends_at ?? null;
   }
 }

--- a/src/types/subscription/subscription-discount-response.ts
+++ b/src/types/subscription/subscription-discount-response.ts
@@ -6,6 +6,6 @@
 
 export interface ISubscriptionDiscountResponse {
   id: string;
-  starts_at: string;
+  starts_at: string | null;
   ends_at?: string | null;
 }


### PR DESCRIPTION
Related docs: https://developer.paddle.com/api-reference/subscriptions/overview

Subscription `discount.startsAt` can now be null