### PR TITLE
docs: update usage example to use LogLevel

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To authenticate, you'll need an API key. You can create and manage API keys in *
 Pass your API key while initializing a new Paddle client.
 
 ``` typescript
-import { Environment, Paddle } from '@paddle/paddle-node-sdk'
+import { Environment, LogLevel, Paddle } from '@paddle/paddle-node-sdk'
 
 const paddle = new Paddle('API_KEY')
 ```
@@ -51,7 +51,7 @@ You can also pass an environment to work with the sandbox:
 ```typescript
 const paddle = new Paddle('API_KEY', {
   environment: Environment.production, // or Environment.sandbox for accessing sandbox API
-  logLevel: 'verbose' // or 'error' for less verbose logging
+  logLevel: LogLevel.verbose // or LogLevel.error for less verbose logging
 })
 ```
 


### PR DESCRIPTION
First time using Paddle and noticed the documentation was still using string literals ('verbose', 'error') for log levels instead of the LogLevel enum. Here's a small PR to update the example in the docs to prevent confusion for new users like myself. Hope it's okay to contribute directly!

Updates the usage example to use the `LogLevel` enum instead of the `'verbose'` or `'error'` string literals:

``` typescript
import { Environment, LogLevel, Paddle } from '@paddle/paddle-node-sdk'

const paddle = new Paddle('API_KEY')
```

```typescript
const paddle = new Paddle('API_KEY', {
  environment: Environment.production, // or Environment.sandbox for accessing sandbox API
  logLevel: LogLevel.verbose // or LogLevel.error for less verbose logging
})
```