### PR TITLE
ci: skip publish if version already exists

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,9 +37,11 @@ jobs:
 
       - name: Check version and publish
         run: |
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
           CURRENT_VERSION=$(node -p "require('./package.json').version")
+
           # Check if version exists in npm registry
-          if npm view "$CURRENT_VERSION" version &>/dev/null; then
+          if npm view "${PACKAGE_NAME}@${CURRENT_VERSION}" version &>/dev/null; then
             echo "Version $CURRENT_VERSION already published, skipping"
             exit 0
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: lts/*
-          cache: "yarn"
+          cache: 'yarn'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install yarn dependencies
@@ -35,10 +35,16 @@ jobs:
       - name: Test
         run: yarn test
 
-      - name: Publish
+      - name: Check version and publish
         run: |
-          VERSION=$(node -p "require('./package.json').version" )
-          if [[ "$VERSION" =~ (rc) ]]; then
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          # Check if version exists in npm registry
+          if npm view "$CURRENT_VERSION" version &>/dev/null; then
+            echo "Version $CURRENT_VERSION already published, skipping"
+            exit 0
+          fi
+
+          if [[ "$CURRENT_VERSION" =~ (rc) ]]; then
             yarn publish:rc
           else
             yarn publish:latest


### PR DESCRIPTION
Check if the version in package.json has already been published to skip the publish step

Uses [npm view](https://docs.npmjs.com/cli/v8/commands/npm-view) to check for the version in all releases, I've gone with this approach instead of comparing against the latest released version as we still use `rc` and `beta` releases this could still cause some issues with missing those

This will result in a command like `npm view @paddle/paddle-node-sdk@2.5.0 version` which will either return the version `2.5.0` or an error
```
npm error code E404
npm error 404 No match found for version 2.5.1
npm error 404
npm error 404  '@paddle/paddle-node-sdk@2.5.1' is not in this registry.
```

Partial solution from https://stackoverflow.com/questions/58804498/only-npm-publish-when-version-changes-in-tfs-build

