### PR TITLE
fix: include exports for non-node environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-node-sdk",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "A Node.js SDK that you can use to integrate Paddle Billing with applications written in server-side JavaScript.",
   "main": "dist/cjs/index.cjs.node.js",
   "module": "dist/esm/index.esm.node.js",
@@ -62,7 +62,23 @@
   },
   "exports": {
     "types": "./dist/types/index.cjs.node.d.ts",
+    "browser": {
+      "import": "./dist/esm/index.esm.edge.js",
+      "require": "./dist/cjs/index.cjs.edge.js"
+    },
+    "bun": {
+      "import": "./dist/esm/index.esm.edge.js",
+      "require": "./dist/cjs/index.cjs.edge.js"
+    },
+    "deno": {
+      "import": "./dist/esm/index.esm.edge.js",
+      "require": "./dist/cjs/index.cjs.edge.js"
+    },
     "worker": {
+      "import": "./dist/esm/index.esm.edge.js",
+      "require": "./dist/cjs/index.cjs.edge.js"
+    },
+    "workerd": {
       "import": "./dist/esm/index.esm.edge.js",
       "require": "./dist/cjs/index.cjs.edge.js"
     },


### PR DESCRIPTION
Related to issue: https://github.com/PaddleHQ/paddle-node-sdk/issues/117

Includes additional exports for non-node environments, allowing the runtime to pick up the `edge` build, which has a replacement implementation for `node:crypto` unavailable in other runtimes.

## Usage with nextjs on cloudflare

As we've seen a couple issue with `@paddle/paddle-node-sdk` and nextjs on cloudflare, here is a usage guide:

Import the `Paddle` class from `@paddle/paddle-node-sdk` in the API route and create the instance in the route handler

```typescript
// app/api/webhook/route.ts

export const runtime = "edge";

import {
  Environment,
  LogLevel,
  Paddle,
  PaddleOptions,
} from "@paddle/paddle-node-sdk";
import { NextRequest } from "next/server";

const paddleOptions: PaddleOptions = {
  environment:
    (process.env.NEXT_PUBLIC_PADDLE_ENV as Environment) ?? Environment.sandbox,
  logLevel: LogLevel.error,
};

export async function GET(request: NextRequest) {
  const paddle = new Paddle(process.env.PADDLE_API_KEY!, paddleOptions);

  return Response.json({ paddle, success: true });
}
```

> Note: This will not work if you create a separate utility outside of the API route i.e. a `getPaddleInstance` utility as it will try and use the node runtime

