### PR TITLE
feat(PaddleOptions): add support for custom headers in API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ When we make [non-breaking changes](https://developer.paddle.com/api-reference/a
 
 This means when upgrading minor versions of the SDK, you may notice type errors. You can safely ignore these or fix by adding additional type guards.
 
+## 2.7.0 - 2025-04-16
+
+### Added
+
+- Added support to pass custom header to the API
+
+---
+
 ## 2.6.0 - 2025-04-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ You can also pass an environment to work with the sandbox:
 ```typescript
 const paddle = new Paddle('API_KEY', {
   environment: Environment.production, // or Environment.sandbox for accessing sandbox API
-  logLevel: LogLevel.verbose // or LogLevel.error for less verbose logging
+  logLevel: LogLevel.verbose, // or LogLevel.error for less verbose logging
+  customHeaders: {
+    'X-Custom-Header': 'value' // Optional custom headers
+  }
 })
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-node-sdk",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "A Node.js SDK that you can use to integrate Paddle Billing with applications written in server-side JavaScript.",
   "main": "dist/cjs/index.cjs.node.js",
   "module": "dist/esm/index.esm.node.js",

--- a/src/internal/api/client.ts
+++ b/src/internal/api/client.ts
@@ -40,6 +40,7 @@ export class Client {
       'Content-Type': 'application/json',
       'user-agent': `PaddleSDK/node ${SDK_VERSION}`,
       'X-Transaction-ID': uuid ?? '',
+      ...this.options.customHeaders,
     };
   }
 

--- a/src/internal/types/config.ts
+++ b/src/internal/types/config.ts
@@ -3,4 +3,5 @@ import { type Environment, type LogLevel } from '../api/index.js';
 export interface PaddleOptions {
   environment?: Environment;
   logLevel?: LogLevel;
+  customHeaders?: Record<string, string>;
 }


### PR DESCRIPTION
## 2.7.0 - 2025-04-16

### Added

- Added support to pass custom header to the API

---
