### PR TITLE
feat: make the subscription cancel request body optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ When we make [non-breaking changes](https://developer.paddle.com/api-reference/a
 
 This means when upgrading minor versions of the SDK, you may notice type errors. You can safely ignore these or fix by adding additional type guards.
 
+## 2.7.1 - 2025-05-07
+
+### Changed
+
+- `subscriptions.cancel` requestBody is now optional
+
+---
+
 ## 2.7.0 - 2025-04-16
 
 ### Added
@@ -36,6 +44,7 @@ This means when upgrading minor versions of the SDK, you may notice type errors.
 - Added exports for bun, deno and cloudflare workers
 
 ---
+
 ## 2.5.0 - 2025-01-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-node-sdk",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "A Node.js SDK that you can use to integrate Paddle Billing with applications written in server-side JavaScript.",
   "main": "dist/cjs/index.cjs.node.js",
   "module": "dist/esm/index.esm.node.js",

--- a/src/resources/subscriptions/index.ts
+++ b/src/resources/subscriptions/index.ts
@@ -142,15 +142,15 @@ export class SubscriptionsResource extends BaseResource {
     return new Subscription(data);
   }
 
-  public async cancel(subscriptionId: string, requestBody: CancelSubscription): Promise<Subscription> {
+  public async cancel(subscriptionId: string, requestBody?: CancelSubscription): Promise<Subscription> {
     const urlWithPathParams = new PathParameters(SubscriptionPaths.cancel, {
       subscription_id: subscriptionId,
     }).deriveUrl();
 
-    const response = await this.client.post<CancelSubscription, Response<ISubscriptionResponse> | ErrorResponse>(
-      urlWithPathParams,
-      requestBody,
-    );
+    const response = await this.client.post<
+      CancelSubscription | undefined,
+      Response<ISubscriptionResponse> | ErrorResponse
+    >(urlWithPathParams, requestBody);
 
     const data = this.handleResponse<ISubscriptionResponse>(response);
 


### PR DESCRIPTION
Related issue: https://github.com/PaddleHQ/paddle-node-sdk/issues/132

## Details

Updates the `requestBody` in `subscription.cancel` to be optional

Before:
```
await paddle.subscription.cancel(subscriptionId, {})
```

After:
```
await paddle.subscription.cancel(subscriptionId)
```