### PR TITLE
feat: add exchangeRate and feeRate to transaction payout totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ When we make [non-breaking changes](https://developer.paddle.com/api-reference/a
 
 This means when upgrading minor versions of the SDK, you may notice type errors. You can safely ignore these or fix by adding additional type guards.
 
+## 2.7.2 - 2025-05-22
+
+### Fixed
+
+- Added support for `exchangeRate` and `feeRate` in transaction completed webhook event's `details.payoutTotals`
+
+---
+
 ## 2.7.1 - 2025-05-07
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-node-sdk",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "A Node.js SDK that you can use to integrate Paddle Billing with applications written in server-side JavaScript.",
   "main": "dist/cjs/index.cjs.node.js",
   "module": "dist/esm/index.esm.node.js",

--- a/src/__tests__/mocks/notifications/transaction-completed.mock.ts
+++ b/src/__tests__/mocks/notifications/transaction-completed.mock.ts
@@ -159,6 +159,8 @@ export const TransactionCompletedMock: IEventsResponse<ITransactionNotificationR
         subtotal: '59900',
         grand_total: '65215',
         currency_code: 'USD',
+        exchange_rate: '1',
+        fee_rate: '0.05',
       },
       tax_rates_used: [
         { totals: { tax: '5315', total: '65215', discount: '0', subtotal: '59900' }, tax_rate: '0.08875' },
@@ -382,6 +384,8 @@ export const TransactionCompletedMockExpectation = {
         subtotal: '59900',
         tax: '5315',
         total: '65215',
+        exchangeRate: '1',
+        feeRate: '0.05',
       },
       taxRatesUsed: [
         {

--- a/src/notifications/entities/shared/transaction-payout-totals-notification.ts
+++ b/src/notifications/entities/shared/transaction-payout-totals-notification.ts
@@ -19,6 +19,8 @@ export class TransactionPayoutTotalsNotification {
   public readonly fee: string;
   public readonly earnings: string;
   public readonly currencyCode: PayoutCurrencyCode;
+  public readonly exchangeRate: string;
+  public readonly feeRate: string;
 
   constructor(transactionPayoutTotals: ITransactionPayoutTotalsNotificationResponse) {
     this.subtotal = transactionPayoutTotals.subtotal;
@@ -32,5 +34,7 @@ export class TransactionPayoutTotalsNotification {
     this.fee = transactionPayoutTotals.fee;
     this.earnings = transactionPayoutTotals.earnings;
     this.currencyCode = transactionPayoutTotals.currency_code;
+    this.exchangeRate = transactionPayoutTotals.exchange_rate;
+    this.feeRate = transactionPayoutTotals.fee_rate;
   }
 }

--- a/src/notifications/types/shared/transaction-payout-totals-notification-response.ts
+++ b/src/notifications/types/shared/transaction-payout-totals-notification-response.ts
@@ -18,4 +18,6 @@ export interface ITransactionPayoutTotalsNotificationResponse {
   fee: string;
   earnings: string;
   currency_code: PayoutCurrencyCode;
+  exchange_rate: string;
+  fee_rate: string;
 }


### PR DESCRIPTION
## 2.7.2 - 2025-05-22

### Fixed

- Added support for `exchangeRate` and `feeRate` in transaction completed webhook event's `details.payoutTotals`

---