### PR TITLE
chore: update dependabot labels and bump version to 2.7.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,10 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: /
+    labels:
+      - dependencies
+      - javascript
+      - norelease
     schedule:
       interval: "weekly"
       day: "monday"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This means when upgrading minor versions of the SDK, you may notice type errors.
 
 - Added PR labels to dependabot config.
 - Dependabot updates
+- Fixed a typo `paddle.businesses.archive` operation.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ When we make [non-breaking changes](https://developer.paddle.com/api-reference/a
 
 This means when upgrading minor versions of the SDK, you may notice type errors. You can safely ignore these or fix by adding additional type guards.
 
+## 2.7.3 - 2025-06-05
+
+### Fixed
+
+- Added PR labels to dependabot config.
+- Dependabot updates
+
+---
+
 ## 2.7.2 - 2025-05-22
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-node-sdk",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "A Node.js SDK that you can use to integrate Paddle Billing with applications written in server-side JavaScript.",
   "main": "dist/cjs/index.cjs.node.js",
   "module": "dist/esm/index.esm.node.js",


### PR DESCRIPTION
## 2.7.3 - 2025-06-05

### Fixed

- Added PR labels to dependabot config.
- Dependabot updates
- Fixed a typo `paddle.businesses.archive` operation.

---