### PR TITLE
feat!: Upgrade minimum node version to 20

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -4,12 +4,10 @@ on:
   push:
     branches:
       - main
-      - v1.x
       - release/beta
   pull_request:
     branches:
       - main
-      - v1.x
       - release/beta
 
 concurrency:
@@ -22,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 18, 20, 22, 24 ]
+        node: [ 20, 22, 24 ]
     permissions:
       contents: read
       actions: write

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -4,12 +4,10 @@ on:
   push:
     branches:
       - main
-      - v1.x
       - release/beta
   pull_request:
     branches:
       - main
-      - v1.x
       - release/beta
 
 concurrency:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - v1.x
 
 jobs:
   run-publish:

--- a/.github/workflows/release-on-push.yml
+++ b/.github/workflows/release-on-push.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - v1.x
 
 jobs:
   release_on_push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ in a response, this weakens the Typescript type but does not cause existing usag
 This means when upgrading minor versions of the SDK, you may notice type errors. You can safely ignore these or fix by
 adding additional type guards.
 
-## 3.0.0 - 2025-07-01
+## 3.0.0 - 2025-07-03
 
 > **Breaking changes:** This version includes major improvements that introduce breaking changes. These are called out
 > below.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ in a response, this weakens the Typescript type but does not cause existing usag
 This means when upgrading minor versions of the SDK, you may notice type errors. You can safely ignore these or fix by
 adding additional type guards.
 
+## 3.0.0 - 2025-07-01
+
+> **Breaking changes:** This version includes major improvements that introduce breaking changes. These are called out
+> below.
+
+### Changed
+
+- **Breaking change:** Updated the minimum required Node.js version to v20.
+- **Breaking change:** Changed default logging level to `error`. You can change it to `verbose` or `none` in the
+  SDK configuration.
+- Changed the typescript configuration to transpile into ES2022
+
+---
+
 ## 2.8.0 - 2025-06-18
 
 ### Added

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,16 +2,30 @@
 
 All breaking changes will be documented in this file to assist with upgrading to newer versions of the SDK.
 
+## v3.0.0
+
+There are two breaking changes in this release:
+
+1. Minimum Node.js version is now 20.0.0.
+    - We decided to drop support for Node.js 18 as it is no longer maintained.
+    - If you are using Node.js version 18 or below, you will need to upgrade to Node.js version 20 or above.
+
+2. Updated default logLevel.
+    - Initially, the default log level was set to `verbose`, but we have changed it to `error` to reduce noise in the
+      logs.
+    - If you want to change the log level, you can do so by passing the `logLevel` option when initializing the SDK.
+
 ## v2.0.0
 
 There are two breaking changes in this release:
 
-1. Minimum Node.js version is now 18.0.0. 
-   - We had to restrict the minimum version as we would like to use native `fetch` API instead of `node-fetch` package.
-   - If you are using Node.js version 16 or below, you will need to upgrade to Node.js version 18 or above.
+1. Minimum Node.js version is now 18.0.0.
+    - We had to restrict the minimum version as we would like to use native `fetch` API instead of `node-fetch` package.
+    - If you are using Node.js version 16 or below, you will need to upgrade to Node.js version 18 or above.
 
 2. `Webhooks.unmarshal` and `Webhooks.isSignatureValid` now returns a promise.
-   - As we started supporting edge runtimes, we had to make these methods async as the edge version of crypto returns a promise.
-   - If you are using these methods, you will need to update your code to handle the promise.
+    - As we started supporting edge runtimes, we had to make these methods async as the edge version of crypto returns a
+      promise.
+    - If you are using these methods, you will need to update your code to handle the promise.
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@paddle/paddle-node-sdk",
-  "version": "2.8.0",
+  "version": "3.0.0",
   "description": "A Node.js SDK that you can use to integrate Paddle Billing with applications written in server-side JavaScript.",
   "main": "dist/cjs/index.cjs.node.js",
   "module": "dist/esm/index.esm.node.js",
   "types": "dist/types/index.cjs.node.d.ts",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "test": "jest",

--- a/src/internal/api/client.ts
+++ b/src/internal/api/client.ts
@@ -17,8 +17,7 @@ export class Client {
     private readonly options: PaddleOptions,
   ) {
     this.baseUrl = this.getBaseUrl(this.options.environment);
-    // TODO - Change the default to `error` in next major version
-    Logger.logLevel = this.options.logLevel ?? LogLevel.verbose;
+    Logger.logLevel = this.options.logLevel ?? LogLevel.error;
   }
 
   private getBaseUrl(environment?: Environment): string {

--- a/src/paddle.ts
+++ b/src/paddle.ts
@@ -30,7 +30,7 @@ export class Paddle {
   private readonly client: Client;
   private readonly defaultPaddleOptions: Partial<PaddleOptions> = {
     environment: Environment.production,
-    logLevel: LogLevel.verbose, // TODO - Change the default to `error` in next major version
+    logLevel: LogLevel.error,
   };
 
   public products: ProductsResource;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,10 @@
 {
   "compilerOptions": {
-    "target": "es2016",
-    "lib": ["ESNext", "dom"],
+    "target": "es2022",
+    "lib": [
+      "ESNext",
+      "dom"
+    ],
     "module": "NodeNext",
     "rootDir": "./src",
     "moduleResolution": "Node",
@@ -30,5 +33,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "skipLibCheck": true
   },
-  "include": ["./src"],
+  "include": [
+    "./src"
+  ]
 }


### PR DESCRIPTION
## 3.0.0 - 2025-07-03

> **Breaking changes:** This version includes major improvements that introduce breaking changes. These are called out
> below.
### Changed

- **Breaking change:** Updated the minimum required Node.js version to v20.
- **Breaking change:** Changed default logging level to `error`. You can change it to `verbose` or `none` in the
  SDK configuration.
- Changed the typescript configuration to transpile into ES2022

---

Fixes: #139 