### PR TITLE
feat: add exchange rate and fee rate to transaction payout totals

### DIFF
--- a/src/__tests__/mocks/notifications/transaction-completed.mock.ts
+++ b/src/__tests__/mocks/notifications/transaction-completed.mock.ts
@@ -182,6 +182,7 @@ export const TransactionCompletedMock: IEventsResponse<ITransactionNotificationR
         subtotal: '59900',
         currency_code: 'USD',
         chargeback_fee: { amount: '0', original: null },
+        exchange_rate: '1',
       },
     },
     checkout: {
@@ -263,6 +264,7 @@ export const TransactionCompletedMockExpectation = {
         subtotal: '59900',
         tax: '5315',
         total: '65215',
+        exchangeRate: '1',
       },
       adjustedTotals: {
         currencyCode: 'USD',

--- a/src/__tests__/mocks/resources/transactions.mock.ts
+++ b/src/__tests__/mocks/resources/transactions.mock.ts
@@ -209,6 +209,8 @@ export const TransactionMock: ITransactionResponse = {
       grand_total: '',
       fee: '',
       earnings: '',
+      exchange_rate: '1',
+      fee_rate: '0.05',
     },
     adjusted_payout_totals: {
       subtotal: '15000',
@@ -218,6 +220,7 @@ export const TransactionMock: ITransactionResponse = {
       chargeback_fee: { amount: '1680', original: { amount: '1500', currency_code: 'USD' } },
       earnings: '15675',
       currency_code: 'AUD',
+      exchange_rate: '1',
     },
     line_items: [
       {

--- a/src/entities/shared/transaction-payout-totals-adjusted.ts
+++ b/src/entities/shared/transaction-payout-totals-adjusted.ts
@@ -16,6 +16,7 @@ export class TransactionPayoutTotalsAdjusted {
   public readonly chargebackFee: ChargebackFee | null;
   public readonly earnings: string;
   public readonly currencyCode: PayoutCurrencyCode;
+  public readonly exchangeRate: string;
 
   constructor(transactionPayoutTotalsAdjusted: ITransactionPayoutTotalsAdjustedResponse) {
     this.subtotal = transactionPayoutTotalsAdjusted.subtotal;
@@ -27,5 +28,6 @@ export class TransactionPayoutTotalsAdjusted {
       : null;
     this.earnings = transactionPayoutTotalsAdjusted.earnings;
     this.currencyCode = transactionPayoutTotalsAdjusted.currency_code;
+    this.exchangeRate = transactionPayoutTotalsAdjusted.exchange_rate;
   }
 }

--- a/src/entities/shared/transaction-payout-totals.ts
+++ b/src/entities/shared/transaction-payout-totals.ts
@@ -19,6 +19,8 @@ export class TransactionPayoutTotals {
   public readonly fee: string;
   public readonly earnings: string;
   public readonly currencyCode: PayoutCurrencyCode;
+  public readonly exchangeRate: string;
+  public readonly feeRate: string;
 
   constructor(transactionPayoutTotals: ITransactionPayoutTotalsResponse) {
     this.subtotal = transactionPayoutTotals.subtotal;
@@ -32,5 +34,7 @@ export class TransactionPayoutTotals {
     this.fee = transactionPayoutTotals.fee;
     this.earnings = transactionPayoutTotals.earnings;
     this.currencyCode = transactionPayoutTotals.currency_code;
+    this.exchangeRate = transactionPayoutTotals.exchange_rate;
+    this.feeRate = transactionPayoutTotals.fee_rate;
   }
 }

--- a/src/notifications/entities/shared/transaction-payout-totals-adjusted-notification.ts
+++ b/src/notifications/entities/shared/transaction-payout-totals-adjusted-notification.ts
@@ -16,6 +16,7 @@ export class TransactionPayoutTotalsAdjustedNotification {
   public readonly chargebackFee: ChargebackFeeNotification | null;
   public readonly earnings: string;
   public readonly currencyCode: PayoutCurrencyCode;
+  public readonly exchangeRate: string;
 
   constructor(transactionPayoutTotalsAdjusted: ITransactionPayoutTotalsAdjustedNotificationResponse) {
     this.subtotal = transactionPayoutTotalsAdjusted.subtotal;
@@ -27,5 +28,6 @@ export class TransactionPayoutTotalsAdjustedNotification {
       : null;
     this.earnings = transactionPayoutTotalsAdjusted.earnings;
     this.currencyCode = transactionPayoutTotalsAdjusted.currency_code;
+    this.exchangeRate = transactionPayoutTotalsAdjusted.exchange_rate;
   }
 }

--- a/src/notifications/types/shared/transaction-payout-totals-adjusted-notification-response.ts
+++ b/src/notifications/types/shared/transaction-payout-totals-adjusted-notification-response.ts
@@ -15,4 +15,5 @@ export interface ITransactionPayoutTotalsAdjustedNotificationResponse {
   chargeback_fee?: IChargebackFeeNotification | null;
   earnings: string;
   currency_code: PayoutCurrencyCode;
+  exchange_rate: string;
 }

--- a/src/types/shared/transaction-payout-totals-adjusted-response.ts
+++ b/src/types/shared/transaction-payout-totals-adjusted-response.ts
@@ -15,4 +15,5 @@ export interface ITransactionPayoutTotalsAdjustedResponse {
   chargeback_fee?: IChargebackFee | null;
   earnings: string;
   currency_code: PayoutCurrencyCode;
+  exchange_rate: string;
 }

--- a/src/types/shared/transaction-payout-totals-response.ts
+++ b/src/types/shared/transaction-payout-totals-response.ts
@@ -18,4 +18,6 @@ export interface ITransactionPayoutTotalsResponse {
   fee: string;
   earnings: string;
   currency_code: PayoutCurrencyCode;
+  exchange_rate: string;
+  fee_rate: string;
 }


### PR DESCRIPTION
Added:
- Added support for `exchange_rate` and `fee_rate` in transaction payout totals