### PR TITLE
fix: Use camel case for operation properties

### DIFF
--- a/src/__tests__/resources/transactions.test.ts
+++ b/src/__tests__/resources/transactions.test.ts
@@ -121,9 +121,9 @@ describe('TransactionsResource', () => {
       description: 'NCD for create',
       type: 'flat',
       recur: false,
-      maximum_recurring_intervals: null,
-      custom_data: { internal_reference: 'create_ref' },
-      restrict_to: ['pri_123'],
+      maximumRecurringIntervals: null,
+      customData: { internal_reference: 'create_ref' },
+      restrictTo: ['pri_123'],
     };
 
     const body: CreateTransactionRequestBody = {
@@ -164,9 +164,9 @@ describe('TransactionsResource', () => {
       description: 'NCD for update',
       type: 'percentage',
       recur: true,
-      maximum_recurring_intervals: 5,
-      custom_data: { internal_reference: 'update_ref' },
-      restrict_to: ['pri_456', 'pri_789'],
+      maximumRecurringIntervals: 5,
+      customData: { internal_reference: 'update_ref' },
+      restrictTo: ['pri_456', 'pri_789'],
     };
 
     const body: UpdateTransactionRequestBody = {
@@ -215,9 +215,9 @@ describe('TransactionsResource', () => {
       description: 'NCD for preview',
       type: 'flat',
       recur: false,
-      maximum_recurring_intervals: null,
-      custom_data: { internal_reference: 'preview_ref' },
-      restrict_to: ['pri_123'],
+      maximumRecurringIntervals: null,
+      customData: { internal_reference: 'preview_ref' },
+      restrictTo: ['pri_123'],
     };
 
     const body: TransactionPreviewRequestBody = {

--- a/src/resources/transactions/operations/non-catalog-discount.ts
+++ b/src/resources/transactions/operations/non-catalog-discount.ts
@@ -12,7 +12,7 @@ export interface NonCatalogDiscount {
   description: string;
   type: DiscountType;
   recur?: boolean;
-  maximum_recurring_intervals?: number | null;
-  custom_data?: ICustomData | null;
-  restrict_to?: string[] | null;
+  maximumRecurringIntervals?: number | null;
+  customData?: ICustomData | null;
+  restrictTo?: string[] | null;
 }


### PR DESCRIPTION
### Fixed

Fixes property casing in https://github.com/PaddleHQ/paddle-node-sdk/pull/191