### PR TITLE
docs(release): v3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ in a response, this weakens the Typescript type but does not cause existing usag
 This means when upgrading minor versions of the SDK, you may notice type errors. You can safely ignore these or fix by
 adding additional type guards.
 
-## [Unreleased]
+## 3.3.0 - 2025-10-07
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-node-sdk",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "A Node.js SDK that you can use to integrate Paddle Billing with applications written in server-side JavaScript.",
   "main": "dist/cjs/index.cjs.node.js",
   "module": "dist/esm/index.esm.node.js",


### PR DESCRIPTION
## [3.3.0 - 2025-10-07](http://github.com/PaddleHQ/paddle-node-sdk/compare/v3.2.1...docs/release-3-3-0)

### Added

- Added support for new payment methods `blik`, `mb_way`, `pix` and `upi`. See [related changelog](https://developer.paddle.com/changelog/2025/blik-mbway-payment-methods?utm_source=dx&utm_medium=paddle-node-sdk).
- Non-catalog discounts on Transactions, see [changelog](https://developer.paddle.com/changelog/2025/custom-discounts?utm_source=dx&utm_medium=paddle-node-sdk)
- Support `retained_fee` field on totals objects to show the fees retained by Paddle for the adjustment.
- `ApiError` will now have `retryAfter` property set for [too_many_requests](https://developer.paddle.com/errors/shared/too_many_requests) errors

### Fixed

- `PricingPreview`, `PricingPreviewDiscounts`, `PricingPreviewDetails`, `PricingPreviewLineItem` types are now exported
