### PR TITLE
Release v3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ adding additional type guards.
 
 ## Unreleased
 
+---
+
+## 3.7.0 - 2026-04-09
+
 ### Added
 
 - `metrics` resource for timeseries metrics: `getActiveSubscribers`, `getMonthlyRecurringRevenue`, `getMonthlyRecurringRevenueChange`, `getRevenue`, `getRefunds`, `getChargebacks`, and `getCheckoutConversion`. See [related changelog](https://developer.paddle.com/changelog/2026/metrics-api?utm_source=dx&utm_medium=paddle-node-sdk).

--- a/README.md
+++ b/README.md
@@ -714,6 +714,35 @@ async function getAllReports(): Promise<Report[]> {
 </details>
 
 <details>
+<summary style="font-size: 1.1rem;">Metrics (metrics.get*)</summary>
+
+The metrics resource returns timeseries data for your account. Pass a date range with `from` (inclusive) and `to` (exclusive) query parameters. See the [metrics API reference](https://developer.paddle.com/api-reference/metrics/overview?utm_source=dx&utm_medium=paddle-node-sdk) for available metrics and fields.
+
+```typescript
+import { Paddle, MetricsTimeseriesRevenue } from '@paddle/paddle-node-sdk'
+
+const paddle = new Paddle('API_KEY')
+
+async function getRevenueTimeseries(): Promise<MetricsTimeseriesRevenue | undefined> {
+  try {
+    const metrics = await paddle.metrics.getRevenue({
+      from: '2026-01-01',
+      to: '2026-01-31',
+    })
+    return metrics
+  } catch (e) {
+    console.error('Error fetching revenue metrics:', e)
+  }
+}
+
+await getRevenueTimeseries()
+```
+
+Other methods follow the same pattern: `paddle.metrics.getActiveSubscribers`, `getMonthlyRecurringRevenue`, `getMonthlyRecurringRevenueChange`, `getRefunds`, `getChargebacks`, and `getCheckoutConversion`.
+
+</details>
+
+<details>
 <summary style="font-size: 1.1rem;">Simulations (simulations.list())</summary>
 
 ```typescript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-node-sdk",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "description": "A Node.js SDK that you can use to integrate Paddle Billing with applications written in server-side JavaScript.",
   "main": "dist/cjs/index.cjs.node.js",
   "module": "dist/esm/index.esm.node.js",


### PR DESCRIPTION
## Added
- `metrics` resource for timeseries metrics: `getActiveSubscribers`, `getMonthlyRecurringRevenue`, `getMonthlyRecurringRevenueChange`, `getRevenue`, `getRefunds`, `getChargebacks`, and `getCheckoutConversion`. See [related changelog](https://developer.paddle.com/changelog/2026/metrics-api?utm_source=dx&utm_medium=paddle-node-sdk).
- Bump to v3.7.0