### PR TITLE
fix: pin pnpm to v10 and approve unrs-resolver build script

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2
         with:
-          version: latest
+          version: 10
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2
         with:
-          version: latest
+          version: 10
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2
         with:
-          version: latest
+          version: 10
 
       - name: Get pnpm store directory
         shell: bash

--- a/package.json
+++ b/package.json
@@ -88,5 +88,10 @@
       "require": "./dist/cjs/index.cjs.node.js"
     }
   },
-  "dependencies": {}
+  "dependencies": {},
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "unrs-resolver"
+    ]
+  }
 }


### PR DESCRIPTION
## Reason for change

Every open PR (and any new push to `main`) is failing CI. Both the **Build & Test** and **Lint** workflows install pnpm with `version: latest` via `pnpm/action-setup`. pnpm `latest` has rolled over to **pnpm 11**, which broke CI in two independent ways:

1. **Build & Test (node 20)** — pnpm 11 requires Node.js `>=22.13` (it `require`s the `node:sqlite` builtin). On the `node: 20` matrix leg it crashes immediately with `ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite`, before installing anything. The `22`/`24` legs are then cancelled (no `fail-fast: false`), so the whole matrix shows red.
2. **Lint** — on the `lts/*` leg pnpm 11 runs, but `pnpm install` now hard-fails with `ERR_PNPM_IGNORED_BUILDS: unrs-resolver@1.11.1`. pnpm 10+ refuses to silently skip a dependency's build script in CI unless it's explicitly allowlisted.

`main` last passed in April when pnpm `latest` was still v10 — nothing in the SDK changed, the floating tool version did.

## Semver

`NONE` — CI/tooling only, no change to published SDK code.

## What has been done

- Pinned `pnpm/action-setup` to `version: 10` in `build-test.yml`, `linting.yml` and `publish.yml`. pnpm 10 supports Node `>=18`, so the `node: 20` matrix leg works again, and CI no longer drifts onto new pnpm majors unannounced.
- Added `pnpm.onlyBuiltDependencies: ["unrs-resolver"]` to `package.json` so the native resolver's build script is approved deterministically — fixes the `ERR_PNPM_IGNORED_BUILDS` lint failure regardless of pnpm version.

## How to test

Locally (clean checkout): `pnpm install` runs with no ignored-build warning, then `pnpm build`, `pnpm test`, `pnpm typecheck:tests`, `pnpm lint`, `pnpm prettier` all pass. CI will confirm across the node 20/22/24 matrix.
