### PR TITLE
Set up Cursor Cloud dev environment (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repository is the **Paddle Node.js SDK** (`@paddle/paddle-node-sdk`) — a server-side
+TypeScript client library for Paddle Billing. It is a **library, not a running service**:
+there is no server, database, container, or long-running process. It has zero runtime
+dependencies and talks to Paddle's hosted REST API only when a consumer app makes live calls.
+
+- Package manager: **pnpm** (v10, matching CI). Node **>= 20** (`engines`).
+- The update script runs `pnpm install`, so dependencies are already installed at session start.
+
+### Standard commands (defined in `package.json`)
+- Build: `pnpm build` (compiles ESM + CJS + types into `dist/`)
+- Test: `pnpm test` (Jest; all HTTP is mocked, no network/API key needed)
+- Test typecheck: `pnpm typecheck:tests`
+- Lint: `pnpm lint` — Format: `pnpm prettier` (`:fix` variants auto-fix)
+
+CI mirrors these in `.github/workflows/build-test.yml` (build + test on Node 20/22/24) and
+`.github/workflows/linting.yml` (lint + prettier).
+
+### Non-obvious gotchas
+- **`src/version.ts` is generated and gitignored.** The `prebuild` step
+  (`scripts/update-env-vars.js`) writes it from the package version. It does NOT end with a
+  trailing newline, so running `pnpm lint` *after* a build reports one `@stylistic/eol-last`
+  error on `src/version.ts`. This is not a source-code problem: in CI the lint job runs on a
+  fresh checkout (no build), so the file is absent and lint passes. To reproduce a clean lint
+  locally, run lint on a fresh tree or `rm -f src/version.ts` before `pnpm lint`.
+- `pnpm lint` prints a harmless deprecation warning about the `@stylistic` `recommended-flat`
+  config; it does not affect the exit code.
+- There is no application to "run". To smoke-test the built SDK, exercise a core feature
+  offline — e.g. verify a webhook signature: `h1 = HMAC-SHA256("<ts>:<body>", secret)` in the
+  header `ts=<unix_ts>;h1=<hash>`, then `await paddle.webhooks.unmarshal(body, secret, sig)`.
+  Note the validator rejects signatures whose `ts` is more than 5 seconds old, so sign with a
+  current timestamp.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up and verifies the development environment for the Paddle Node.js SDK, and documents durable, non-obvious setup guidance for future Cursor Cloud agents.

This repository is a **library** (`@paddle/paddle-node-sdk`), not a running service — there is no server/DB/container. Verification therefore covers build, tests, typecheck, lint, format, and an offline smoke test of a core feature (webhook signature verification).

## Changes

- Add `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering: package manager (pnpm v10 / Node >= 20), standard commands (already in `package.json`), and the key gotcha that `src/version.ts` is generated + gitignored and lacks a trailing newline (so `pnpm lint` after a build reports one `eol-last` error; CI lints a fresh tree where the file is absent).

The update script is configured separately as `pnpm install` (minimal, idempotent). No source code was modified.

## Verification

All commands run from the repo root:

- `pnpm build` — OK (`dist/` generated)
- `pnpm test` — 34 suites / 275 tests passed
- `pnpm typecheck:tests` — OK
- `pnpm prettier` — clean
- `pnpm lint` — 0 errors (on a fresh tree without the generated `src/version.ts`)
- Hello-world: built SDK verifies a real `transaction.completed` webhook signature, parses it into a typed entity, and rejects a tampered signature

[full_verification.log](https://cursor.com/agents/bc-04e0345a-0064-42ec-b07f-90c98c836e84/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffull_verification.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04e0345a-0064-42ec-b07f-90c98c836e84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04e0345a-0064-42ec-b07f-90c98c836e84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

