### PR TITLE
Release v3.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,13 +24,20 @@ adding additional type guards.
 
 ---
 
-## 3.9.0 - 2026-08-07
+## 3.10.0 - 2026-08-07
+
+### Added
+
+- Added support for the `notification_setting_cannot_be_duplicate` request error returned when creating or updating
+  notification settings.
+
+---
+
+## 3.9.0 - 2026-08-06
 
 ### Added
 
 - Added `rotatable` to API key notifications to indicate whether an API key can be rotated.
-- Added support for the `notification_setting_cannot_be_duplicate` request error returned when creating or updating
-  notification settings.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ adding additional type guards.
 
 ## Unreleased
 
+---
+
+## 3.9.0 - 2026-08-07
+
 ### Added
 
 - Added `rotatable` to API key notifications to indicate whether an API key can be rotated.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-node-sdk",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "A Node.js SDK that you can use to integrate Paddle Billing with applications written in server-side JavaScript.",
   "main": "dist/cjs/index.cjs.node.js",
   "module": "dist/esm/index.esm.node.js",


### PR DESCRIPTION
## Summary
- Bump package version to **3.10.0** (3.9.0 is already published on npm from [#230](https://github.com/PaddleHQ/paddle-node-sdk/pull/230))
- Promote Unreleased changelog for `notification_setting_cannot_be_duplicate` into **3.10.0** (2026-08-07)
- Record **3.9.0** (2026-08-06) retrospectively for the `rotatable` API key notification field already on npm

## Test plan
- [ ] Confirm `package.json` version is `3.10.0`
- [ ] Confirm CHANGELOG has `3.10.0` (duplicate notification setting error) and `3.9.0` (`rotatable`), with Unreleased empty
- [ ] After merge, publish workflow publishes `@paddle/paddle-node-sdk@3.10.0` (3.9.0 already exists so it would have been skipped)