### PR TITLE
convertToSnakeCase corrupts custom_data keys in simulation payloads — carve-out only works at top-level

### DIFF
--- a/src/internal/api/case-helpers.ts
+++ b/src/internal/api/case-helpers.ts
@@ -1,16 +1,3 @@
-interface CustomData {
-  customData: unknown;
-}
-
-interface ObjectWithData {
-  data: Record<string, unknown>;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function isTopLevelCustomDataCamel(input: any): input is CustomData {
-  return 'customData' in input;
-}
-
 function isObject(input: unknown): boolean {
   return input != null && typeof input === 'object';
 }
@@ -25,7 +12,7 @@ function snakeCase(input: string): string {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function decamelizeKeys(obj: any): ObjectWithData {
+function decamelizeKeys(obj: any): any {
   if (
     !isObject(obj) ||
     obj instanceof Date ||
@@ -50,7 +37,11 @@ function decamelizeKeys(obj: any): ObjectWithData {
     output = {};
     for (const key in obj) {
       if (Object.prototype.hasOwnProperty.call(obj, key)) {
-        output[snakeCase(key)] = decamelizeKeys(obj[key]);
+        if (key === 'customData') {
+          output['custom_data'] = obj[key];
+        } else {
+          output[snakeCase(key)] = decamelizeKeys(obj[key]);
+        }
       }
     }
   }
@@ -62,13 +53,5 @@ export function convertToSnakeCase(input: unknown) {
     return input;
   }
 
-  if (isTopLevelCustomDataCamel(input)) {
-    // top level customData
-    const { customData, ...rest } = input;
-    const result = decamelizeKeys(rest);
-    return { ...result, custom_data: customData };
-  } else {
-    // phew
-    return decamelizeKeys(input);
-  }
+  return decamelizeKeys(input);
 }


### PR DESCRIPTION
moved `customData` → `custom_data` carve-out into `decamelizeKeys` so it applies at any nesting depth, not just top level

Found via automated repo scanning, fix written and reviewed before opening.
